### PR TITLE
Fix: biastee .get TypeError 

### DIFF
--- a/src/modules/adsb-pi-setup/filesystem/root/usr/local/share/adsb-pi-setup/utils.py
+++ b/src/modules/adsb-pi-setup/filesystem/root/usr/local/share/adsb-pi-setup/utils.py
@@ -232,7 +232,7 @@ class EnvFile:
             "checked" if env_values["MLAT_PRIVACY"] == "--privacy" else ""
         )
         metadata["biast"] = (
-            "checked" if env_values.get["FEEDER_READSB_ENABLE_BIASTEE"] == "true" else ""
+            "checked" if env_values.get("FEEDER_READSB_ENABLE_BIASTEE") == "true" else ""
         )
         metadata["heywhatsthat"] = (
             "checked" if env_values["HEYWHATSTHAT"] == "1" else ""


### PR DESCRIPTION
```
Jul 04 17:48:45 adsb-feeder flask[594]: Traceback (most recent call last):
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/lib/python3.9/dist-packages/flask/app.py", line 2528, in wsgi_app
Jul 04 17:48:45 adsb-feeder flask[594]:     response = self.full_dispatch_request()
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/lib/python3.9/dist-packages/flask/app.py", line 1825, in full_dispatch_request
Jul 04 17:48:45 adsb-feeder flask[594]:     rv = self.handle_user_exception(e)
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/lib/python3.9/dist-packages/flask/app.py", line 1823, in full_dispatch_request
Jul 04 17:48:45 adsb-feeder flask[594]:     rv = self.dispatch_request()
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/lib/python3.9/dist-packages/flask/app.py", line 1799, in dispatch_request
Jul 04 17:48:45 adsb-feeder flask[594]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/share/adsb-pi-setup/app.py", line 388, in director
Jul 04 17:48:45 adsb-feeder flask[594]:     return setup()
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/share/adsb-pi-setup/app.py", line 443, in setup
Jul 04 17:48:45 adsb-feeder flask[594]:     "setup.html", env_values=ENV_FILE.envs, metadata=ENV_FILE.metadata
Jul 04 17:48:45 adsb-feeder flask[594]:   File "/usr/local/share/adsb-pi-setup/utils.py", line 235, in metadata
Jul 04 17:48:45 adsb-feeder flask[594]:     "checked" if env_values.get["FEEDER_READSB_ENABLE_BIASTEE"] == "true" else ""
Jul 04 17:48:45 adsb-feeder flask[594]: TypeError: 'builtin_function_or_method' object is not subscriptable
Jul 04 17:48:45 adsb-feeder flask[594]: 127.0.0.1 - - [04/Jul/2023 17:48:45] "GET / HTTP/1.1" 500 -
```