### PR TITLE
Sorted and branded aggregators in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,24 @@ Currently we are building images for
 
 The idea is to create a "complete" ADS-B feeder that feeds pretty much all of the ADS-B flight trackers / aggregators.
 At this point it supports:
-- [adsb.lol](http://adsb.lol)
-- [adsb.one](http://adsb.one)
-- [adsb.fi](http://adsb.fi)
-- [planespotters.net](http://planespotters.net)
-- [TheAirTraffic.com](http://theairtraffic.com)
-- [Fly Italy ADSB](https://flyitalyadsb.com)
-- [AVDelphi](https://www.avdelphi.com)
-- [ADSBexchange](https://adsbexchange.com)
-- [PlaneFinder](https://planefinder.net)
-- [Plane.watch](https://plane.watch)
-- [OpenSky Network](https://opensky-network.org)
-- [Radar Virtuel](https://www.radarvirtuel.com)
+- [adsb.fi](https://adsb.fi)
+- [adsb.lol](https://adsb.lol)
+- [ADS-B Exchange](https://adsbexchange.com)
 - [ADSBHub](https://adsbhub.org)
+- [ADS-B One](https://adsb.one)
+- [AVDelphi](https://www.avdelphi.com)
 - [FlightAware](https://flightaware.com)
-- [RadarBox](https://www.radarbox.com)
 - [FlightRadar24](https://www.flightradar24.com)
+- [Fly Italy Adsb](https://flyitalyadsb.com)
+- [FLYOVR.io](https://www.flyovr.io/)
+- [OpenSky Network](https://opensky-network.org)
+- [Plane.watch](https://plane.watch)
+- [Plane Finder](https://planefinder.net)
+- [Planespotters.net](http://planespotters.net)
+- [RadarBox](https://www.radarbox.com)
+- [RadarPlane](https://radarplane.com/)
+- [Radar Virtuel](https://www.radarvirtuel.com)
+- [TheAirTraffic](http://theairtraffic.com)
 
 The goal of this project is to make things as simple as possible for the non-technical user.
 


### PR DESCRIPTION
- Added RadarPlane and FLYOVR.IO
- Rebranded sites per their branding guidelines
- Alpha-sorted  aggegators (not meant as an endorsement / promotion of any of them, just a straight alpha-sort)