### PR TITLE
Tweak feed status display.

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -116,7 +116,7 @@ class AdsbIm:
             ["flightradar", "flightradar24", "https://www.flightradar24.com/", "/fr24-monitor.json"],
             ["planewatch", "Plane.watch", "https:/plane.watch/desktop.html", ""],
             ["flightaware", "FlightAware", "https://www.flightaware.com/live/map", "/fa-status"],
-            ["radarbox", "RadarBox", "https://www.radarbox.com/coverage-map", ""],
+            ["radarbox", "RadarBox", "https://www.radarbox.com/coverage-map", "https://www.radarbox.com/stations/<FEEDER_RADARBOX_SN>"],
             ["planefinder", "PlaneFinder", "https://planefinder.net/", "/planefinder-stat"],
             ["adsbhub", "ADSBHub", "https://www.adsbhub.org/coverage.php", ""],
             ["opensky", "OpenSky", "https://opensky-network.org/network/explorer", "https://opensky-network.org/receiver-profile?s=<FEEDER_OPENSKY_SERIAL>"],

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/index.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/index.html
@@ -235,7 +235,7 @@
         $("#" + agg + "mlat").text(data["mlat"]);
         if (data["beast"] == "+" && data["mlat"] == "+") {
           $("#" + agg + "span").addClass('text-success')
-        } else if (data["beast"] == "-" || data["mlat"] == "-") {
+        } else if (data["beast"] == "-") {
           $("#" + agg + "span").addClass('text-danger')
         } else {
           $("#" + agg + "span").addClass('text-dark')

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/index.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/index.html
@@ -235,7 +235,9 @@
         $("#" + agg + "mlat").text(data["mlat"]);
         if (data["beast"] == "+" && data["mlat"] == "+") {
           $("#" + agg + "span").addClass('text-success')
-        } else if (data["beast"] == "-") {
+        } else if (data["beast"] == "+" && data["mlat"] == "-") {
+          $("#" + agg + "span").addClass('text-warning')
+        } else if (data["beast"] == "-" && data["mlat"] == "-") {
           $("#" + agg + "span").addClass('text-danger')
         } else {
           $("#" + agg + "span").addClass('text-dark')


### PR DESCRIPTION
- Do not show feed as down (red) when only mlat is down. If mlat is enabled and down, treat it same as if it is disabled (black).
- Show link to RadarBox status if the station serial no. is available.