### PR TITLE
Redesign the handling of .env vs config.json

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -20,25 +20,27 @@ from time import sleep
 from typing import Dict, List
 from zlib import compress
 
+from utils.config import (
+    read_values_from_env_file,
+    write_values_to_config_json,
+    write_values_to_env_file,
+)
+
+if not os.path.exists("/opt/adsb/config/config.json"):
+    # this must be either a first run after an install,
+    # or the first run after an upgrade from a version that didn't use the config.json
+    values = read_values_from_env_file()
+    write_values_to_config_json(values)
+
 # nofmt: on
 # isort: off
 from flask import Flask, flash, redirect, render_template, request, send_file, url_for
 
-# this initial setup is not a great look... but I don't want to move this into a separate
-# applications... if we have no JSON config file, we need create it from a .env file and
-# then write the data back (which creates the JSON file)
-if not os.path.exists("/opt/adsb/config/config.json"):
-    open("/opt/adsb/config/.env.flag", "w").close()
-
-from utils import Constants
-
-if os.path.exists("/opt/adsb/config/.env.flag"):
-    Constants().writeback_env()
-    os.remove("/opt/adsb/config/.env.flag")
 
 from utils import (
     ADSBHub,
     Background,
+    Constants,
     Env,
     FlightAware,
     FlightRadar24,
@@ -219,7 +221,7 @@ class AdsbIm:
         self._routemanager.add_proxy_routes(self.proxy_routes)
         debug = os.environ.get("ADSBIM_DEBUG") is not None
         self._debug_cleanup()
-        self._constants.writeback_env()
+        write_values_to_env_file(self._constants.envs)
         self.update_dns_state()
         # in no_server mode we want to exit right after the housekeeping, so no
         # point in running this in the background
@@ -327,9 +329,7 @@ class AdsbIm:
         adsb_path = pathlib.Path("/opt/adsb/config")
         data = tempfile.TemporaryFile()
         with zipfile.ZipFile(data, mode="w") as backup_zip:
-            backup_zip.write(adsb_path / ".env", arcname=".env")
-            for f in adsb_path.glob("*.yml"):
-                backup_zip.write(f, arcname=os.path.basename(f))
+            backup_zip.write(adsb_path / "json.conf", arcname="json.conf")
             if include_graphs:
                 graphs_path = pathlib.Path(
                     adsb_path / "ultrafeeder/graphs1090/rrd/localhost.tar.gz"
@@ -368,6 +368,8 @@ class AdsbIm:
             if file.filename.endswith(".zip"):
                 filename = secure_filename(file.filename)
                 restore_path = pathlib.Path("/opt/adsb/config/restore")
+                # clean up the restore path when saving a fresh zipfile
+                shutil.rmtree(restore_path, ignore_errors=True)
                 restore_path.mkdir(mode=0o644, exist_ok=True)
                 file.save(restore_path / filename)
                 print_err(f"saved restore file to {restore_path / filename}")
@@ -390,11 +392,17 @@ class AdsbIm:
             with zipfile.ZipFile(restore_path / filename, "r") as restore_zip:
                 for name in restore_zip.namelist():
                     print_err(f"found file {name} in archive")
-                    # only accept the .env file and simple .yml filenames
+                    # remove files with a name that results in a path that doesn't start with our decompress path
+                    if not str(
+                        os.path.normpath(os.path.join(restore_path, name))
+                    ).startswith(str(restore_path)):
+                        print_err(f"restore skipped for path breakout name: {name}")
+                        continue
+                    # only accept the .env file and config.json and files for ultrafeeder
                     if (
                         name != ".env"
+                        and name != "config.json"
                         and not name.startswith("ultrafeeder/")
-                        and (not name.endswith(".yml") or name != secure_filename(name))
                     ):
                         continue
                     restore_zip.extract(name, restore_path)
@@ -443,13 +451,23 @@ class AdsbIm:
                         shutil.move(adsb_path / name, restore_path / (name + ".dist"))
                     shutil.move(restore_path / name, adsb_path / name)
                     if name == ".env":
-                        # this is pretty hacky, but we should at least try to not completely get this wrong
+                        if "config.json" in request.form.keys():
+                            # if we are restoring the config.json file, we don't need to restore the .env
+                            # this should never happen, but better safe than sorry
+                            continue
+                        # so this is a backup from an older system, let's try to make this work
+                        # read them in, replace the ones that match a norestore tag with the current value
+                        # and then write this all back out as config.json
+                        values = read_values_from_env_file()
                         for e in self._constants._env:
                             if "norestore" in e.tags:
                                 # this overwrites the value in the file we just restored with the current value of the running image,
                                 # iow it doesn't restore that value from the backup
-                                e._reconcile(e.value)
-            self._constants.re_read_env()
+                                values[e.name] = e.value
+                        write_values_to_config_json(values)
+            # now that everything has been moved into place we need to read all the values from config.json
+            for e in self._constants._env:
+                e._reconcile(e._value, pull=True)
             self.update_boardname()
             # make sure we are connected to the right Zerotier network
             zt_network = self._constants.env_by_tags("zerotierid").value
@@ -899,7 +917,7 @@ class AdsbIm:
         )
 
         # let's make sure we write out the updated ultrafeeder config
-        self._constants.writeback_env()
+        write_values_to_env_file(self._constants.envs)
 
         # if the button simply updated some field, stay on the same page
         if not seen_go:

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/__init__.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/__init__.py
@@ -1,3 +1,9 @@
+from .config import (
+    read_values_from_config_json,
+    write_values_to_config_json,
+    read_values_from_env_file,
+    write_values_to_env_file,
+)
 from .constants import Constants
 from .environment import Env
 from .flask import RouteManager, check_restart_lock

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/config.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/config.py
@@ -1,0 +1,86 @@
+import json
+from .util import print_err
+
+
+ENV_FILE_PATH = "/opt/adsb/config/.env"
+USER_ENV_FILE_PATH = "/opt/adsb/config/.env.user"
+JSON_FILE_PATH = "/opt/adsb/config/config.json"
+
+
+def read_values_from_config_json():
+    print_err("reading .json file")
+    ret = {}
+    try:
+        ret = json.load(open(JSON_FILE_PATH, "r"))
+    except:
+        print_err("Failed to read .json file")
+    return ret
+
+
+def write_values_to_config_json(data: dict):
+    print_err("writing .json file")
+    json.dump(data, open(JSON_FILE_PATH, "w"))
+
+
+def read_values_from_env_file():
+    print_err("reading .env file")
+    ret = {}
+    try:
+        with open(ENV_FILE_PATH, "r") as f:
+            for line in f.readlines():
+                if line.strip().startswith("#"):
+                    continue
+                key, var = line.partition("=")[::2]
+                if key in conversion.keys():
+                    key = conversion[key]
+                ret[key.strip()] = var.strip()
+    except:
+        print_err("Failed to read .env file")
+    return ret
+
+
+def write_values_to_env_file(values):
+    print_err("writing .env file")
+    with open(ENV_FILE_PATH, "w") as f:
+        for key, value in sorted(values.items()):
+            # _ADSBIM_STATE variables aren't needed in the .env file
+            if key.startswith("_ADSBIM_STATE"):
+                continue
+            f.write(f"{key.strip()}={value.strip() if type(value) == str else value}\n")
+    # write the user env in the form that can be easily inserted into the yml file
+    # using the name here so it comes from the values passed in
+    val = values.get("_ADSBIM_STATE_EXTRA_ENV", None)
+    if val:
+        with open(USER_ENV_FILE_PATH, "w") as f:
+            lines = val.split("\r\n")
+            for line in lines:
+                if line.strip():
+                    f.write(f"      - {line.strip()}\n")
+
+
+conversion = {
+    # web ports, needed in docker-compose files
+    "_ADSBIM_STATE_WEBPORT": "AF_WEBPORT",
+    "_ADSBIM_STATE_DAZZLE_PORT": "AF_DAZZLEPORT",
+    "_ADSBIM_STATE_TAR1090_PORT": "AF_TAR1090PORT",
+    "_ADSBIM_STATE_PIAWAREMAP_PORT": "AF_PIAWAREMAP_PORT",
+    "_ADSBIM_STATE_PIAWARESTAT_PORT": "AF_PIAWARESTAT_PORT",
+    "_ADSBIM_STATE_FLIGHTRADAR_PORT": "AF_FLIGHTRADAR_PORT",
+    "_ADSBIM_STATE_PLANEFINDER_PORT": "AF_PLANEFINDER_PORT",
+    # flag variables, used by shell scripts
+    "_ADSBIM_STATE_IS_BASE_CONFIG_FINISHED": "AF_IS_BASE_CONFIG_FINISHED",
+    "_ADSBIM_STATE_IS_FLIGHTRADAR24_ENABLED": "AF_IS_FLIGHTRADAR24_ENABLED",
+    "_ADSBIM_STATE_IS_PLANEWATCH_ENABLED": "AF_IS_PLANEWATCH_ENABLED",
+    "_ADSBIM_STATE_IS_FLIGHTAWARE_ENABLED": "AF_IS_FLIGHTAWARE_ENABLED",
+    "_ADSBIM_STATE_IS_RADARBOX_ENABLED": "AF_IS_RADARBOX_ENABLED",
+    "_ADSBIM_STATE_IS_PLANEFINDER_ENABLED": "AF_IS_PLANEFINDER_ENABLED",
+    "_ADSBIM_STATE_IS_ADSBHUB_ENABLED": "AF_IS_ADSBHUB_ENABLED",
+    "_ADSBIM_STATE_IS_OPENSKY_ENABLED": "AF_IS_OPENSKY_ENABLED",
+    "_ADSBIM_STATE_IS_RADARVIRTUEL_ENABLED": "AF_IS_RADARVIRTUEL_ENABLED",
+    "_ADSBIM_STATE_IS_1090UK_ENABLED": "AF_IS_1090UK_ENABLED",
+    "_ADSBIM_STATE_IS_AIRSPY_ENABLED": "AF_IS_AIRSPY_ENABLED",
+    "_ADSBIM_STATE_IS_SECURE_IMAGE": "AF_IS_SECURE_IMAGE",
+    "_ADSBIM_STATE_IS_NIGHTLY_BASE_UPDATE_ENABLED": "AF_IS_NIGHTLY_BASE_UPDATE_ENABLED",
+    "_ADSBIM_STATE_IS_NIGHTLY_FEEDER_UPDATE_ENABLED": "AF_IS_NIGHTLY_FEEDER_UPDATE_ENABLED",
+    "_ADSBIM_STATE_IS_NIGHTLY_CONTAINER_UPDATE_ENABLED": "AF_IS_NIGHTLY_CONTAINER_UPDATE_ENABLED",
+}

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/environment.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/environment.py
@@ -2,13 +2,8 @@ import json
 from os import path
 import re
 from typing import List, Union
-
+from utils.config import read_values_from_config_json, write_values_to_config_json
 from utils.util import print_err
-
-ENV_FILE_PATH = "/opt/adsb/config/.env"
-USER_ENV_FILE_PATH = "/opt/adsb/config/.env.user"
-ENV_FLAG_FILE_PATH = "/opt/adsb/config/.env.flag"
-JSON_FILE_PATH = "/opt/adsb/config/config.json"
 
 
 # extend the truthy concept to exclude all non-empty string except a few specific ones ([Tt]rue, [Oo]n, 1)
@@ -57,63 +52,17 @@ class Env:
         else:
             self._write_value_to_file(value)
 
-    def _get_values_from_file(self):
-        ret = json.load(open(JSON_FILE_PATH, "r"))
-        return ret
-
-    def _get_values_from_env_file(self):
-        ret = {}
-        try:
-            with open(ENV_FILE_PATH, "r") as f:
-                for line in f.readlines():
-                    if line.strip().startswith("#"):
-                        continue
-                    key, var = line.partition("=")[::2]
-                    if key in conversion.keys():
-                        key = conversion[key]
-                    ret[key.strip()] = var.strip()
-        except:
-            pass
-
-        return ret
-
     def _get_value_from_file(self):
-        # this is ugly because we need to be able to import a .env file
-        # if there is no json file, but the moment we import the first
-        # Env from the .env file, it will create the json file
-        # so we rely on the calling code to have provided us with a flag file
-        if path.exists(ENV_FLAG_FILE_PATH):
-            return self._get_values_from_env_file().get(self._name, None)
-        return self._get_values_from_file().get(self._name, None)
-
-    def _write_file(self, values):
-        json.dump(values, open(JSON_FILE_PATH, "w"))
-        with open(ENV_FILE_PATH, "w") as f:
-            for key, value in sorted(values.items()):
-                # _ADSBIM_STATE variables aren't needed in the .env file
-                if key.startswith("_ADSBIM_STATE"):
-                    continue
-                f.write(
-                    f"{key.strip()}={value.strip() if type(value) == str else value}\n"
-                )
-        # write the user env in the form that can be easily inserted into the yml file
-        # using the name here so it comes from the values passed in
-        val = values.get("_ADSBIM_STATE_EXTRA_ENV", "\r\n")
-        if val:
-            with open(USER_ENV_FILE_PATH, "w") as f:
-                lines = val.split("\r\n")
-                for line in lines:
-                    if line.strip():
-                        f.write(f"      - {line.strip()}\n")
+        return read_values_from_config_json().get(self._name, None)
 
     def _write_value_to_file(self, new_value):
-        values = self._get_values_from_file()
+        values = read_values_from_config_json()
         if any(t == "false_is_zero" for t in self.tags):
             new_value = "1" if is_true(new_value) else "0"
         if any(t == "false_is_empty" for t in self.tags):
             new_value = "1" if is_true(new_value) else ""
         values[self._name] = new_value
-        self._write_file(values)
+        write_values_to_config_json(values)
 
     def __str__(self):
         return f"Env({self._name}, {self._value})"
@@ -160,32 +109,3 @@ class Env:
         if not self._tags:
             return []
         return self._tags
-
-
-conversion = {
-    # web ports, needed in docker-compose files
-    "_ADSBIM_STATE_WEBPORT": "AF_WEBPORT",
-    "_ADSBIM_STATE_DAZZLE_PORT": "AF_DAZZLEPORT",
-    "_ADSBIM_STATE_TAR1090_PORT": "AF_TAR1090PORT",
-    "_ADSBIM_STATE_PIAWAREMAP_PORT": "AF_PIAWAREMAP_PORT",
-    "_ADSBIM_STATE_PIAWARESTAT_PORT": "AF_PIAWARESTAT_PORT",
-    "_ADSBIM_STATE_FLIGHTRADAR_PORT": "AF_FLIGHTRADAR_PORT",
-    "_ADSBIM_STATE_PLANEFINDER_PORT": "AF_PLANEFINDER_PORT",
-    # flag variables, used by shell scripts
-    "_ADSBIM_STATE_IS_BASE_CONFIG_FINISHED": "AF_IS_BASE_CONFIG_FINISHED",
-    "_ADSBIM_STATE_IS_FLIGHTRADAR24_ENABLED": "AF_IS_FLIGHTRADAR24_ENABLED",
-    "_ADSBIM_STATE_IS_PLANEWATCH_ENABLED": "AF_IS_PLANEWATCH_ENABLED",
-    "_ADSBIM_STATE_IS_FLIGHTAWARE_ENABLED": "AF_IS_FLIGHTAWARE_ENABLED",
-    "_ADSBIM_STATE_IS_RADARBOX_ENABLED": "AF_IS_RADARBOX_ENABLED",
-    "_ADSBIM_STATE_IS_PLANEFINDER_ENABLED": "AF_IS_PLANEFINDER_ENABLED",
-    "_ADSBIM_STATE_IS_ADSBHUB_ENABLED": "AF_IS_ADSBHUB_ENABLED",
-    "_ADSBIM_STATE_IS_OPENSKY_ENABLED": "AF_IS_OPENSKY_ENABLED",
-    "_ADSBIM_STATE_IS_RADARVIRTUEL_ENABLED": "AF_IS_RADARVIRTUEL_ENABLED",
-    "_ADSBIM_STATE_IS_1090UK_ENABLED": "AF_IS_1090UK_ENABLED",
-    "_ADSBIM_STATE_IS_DOZZLE_ENABLED": "AF_IS_DOZZLE_ENABLED",
-    "_ADSBIM_STATE_IS_AIRSPY_ENABLED": "AF_IS_AIRSPY_ENABLED",
-    "_ADSBIM_STATE_IS_SECURE_IMAGE": "AF_IS_SECURE_IMAGE",
-    "_ADSBIM_STATE_IS_NIGHTLY_BASE_UPDATE_ENABLED": "AF_IS_NIGHTLY_BASE_UPDATE_ENABLED",
-    "_ADSBIM_STATE_IS_NIGHTLY_FEEDER_UPDATE_ENABLED": "AF_IS_NIGHTLY_FEEDER_UPDATE_ENABLED",
-    "_ADSBIM_STATE_IS_NIGHTLY_CONTAINER_UPDATE_ENABLED": "AF_IS_NIGHTLY_CONTAINER_UPDATE_ENABLED",
-}

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/system.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/system.py
@@ -48,7 +48,9 @@ class Restart:
             print_err("Calling /opt/adsb/adsb-system-restart.sh")
             # discard output, script is logging directly to /opt/adsb/adsb-setup.log
             subprocess.run(
-                "/usr/bin/bash /opt/adsb/adsb-system-restart.sh", shell=True, capture_output=True,
+                "/usr/bin/bash /opt/adsb/adsb-system-restart.sh",
+                shell=True,
+                capture_output=True,
             )
             return True
 
@@ -129,23 +131,6 @@ class System:
         else:
             return response.text, response.status_code
         return None, status
-
-    def _get_backup_data(self):
-        data = io.BytesIO()
-        with zipfile.ZipFile(data, mode="w") as backup_zip:
-            backup_zip.write(self._constants.env_file_path, arcname=".env")
-            for f in self._constants.data_path.glob("*.yml"):
-                backup_zip.write(f, arcname=os.path.basename(f))
-            for f in self._constants.data_path.glob("*.yaml"):  # FIXME merge with above
-                backup_zip.write(f, arcname=os.path.basename(f))
-            uf_path = pathlib.Path(self._constants.data_path / "ultrafeeder")
-            if uf_path.is_dir():
-                for f in uf_path.rglob("*"):
-                    backup_zip.write(
-                        f, arcname=f.relative_to(self._constants.data_path)
-                    )
-        data.seek(0)
-        return data
 
 
 class Version:


### PR DESCRIPTION
Instead of trying to do all this implicitly with magic code and magic flag files, add four very simple single use functions to read and write either .env or config.json. Use those to set up config.json from a .env file if necessary.

With this in place, simplify and fix the backup and restore code.

Creating new backups, we no longer store the .env file since it is derived from the config.json.
Restoring an old backup, we load the .env file and create a config.json file from it, the same way we would do it at app start.