### PR TITLE
backup: streamed zipfile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,16 @@ ssh-control:
 # we make a SSH control port to use with rsync.
 	ssh -M -S /tmp/adsb-setup-ssh-control -fnNT root@$(HOST)
 
+sync-and-update-nocontainer:
+# sync relevant files and update
+	ssh -O check -S /tmp/adsb-setup-ssh-control root@$(HOST) || make ssh-control
+
+	# sync over changes from local repo
+	make sync-py-control
+
+	# restart webinterface
+	ssh -S /tmp/adsb-setup-ssh-control root@$(HOST) systemctl restart adsb-setup
+
 sync-and-update:
 # sync relevant files and update
 	ssh -O check -S /tmp/adsb-setup-ssh-control root@$(HOST) || make ssh-control

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -459,9 +459,9 @@ class AdsbIm:
                 if value == "1":
                     print_err(f"restoring {name}")
                     dest = adsb_path / name
-                    if os.path.isfile(dest):
+                    if dest.is_file():
                         shutil.move(dest, adsb_path / (name + ".dist"))
-                    elif os.path.isdir(dest):
+                    elif dest.is_dir():
                         shutil.rmtree(dest, ignore_errors=True)
 
                     shutil.move(restore_path / name, dest)


### PR DESCRIPTION
When clicking the download button for the backup options, the download only starts once the zipfile has been created completely. This results in delayed user feedback which is never pretty, potentially leading to multiple button clicks which will create multiple tempfiles.

Instead of creating a zipfile and writing it to a tempfile, use a pipe. A thread is started which writes the zipped data to the pipe. Flasks send_file will read the data from the pipe so the download can instantly start while the zipfile is being created.

The new approach also means that using the backup function no longer causes any sd-card wear.