### PR TITLE
dietpi IOB workaround: set NTP=1

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/constants.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/constants.py
@@ -328,7 +328,7 @@ class Constants:
             "AF_IS_SECURE_IMAGE",
             is_mandatory=False,
             default="False",
-            tags=["secure_image", "is_enabled"],
+            tags=["secure_image", "is_enabled", "norestore"],
         ),
         Env(
             "AF_IS_FLIGHTRADAR24_ENABLED",

--- a/src/variants/iob-dietpi/Automation_Custom_Script.sh
+++ b/src/variants/iob-dietpi/Automation_Custom_Script.sh
@@ -8,6 +8,7 @@ apt install -y --no-install-recommends python3-flask python3-requests
 # when chrony is installed it's imperative that CONFIG_NTP_MODE=0
 # (custom/disabled) is set in dietpi.txt to avoid breakage of dietpi-update
 apt install -y --no-install-recommends chrony
+sed -i -e 's/^CONFIG_NTP_MODE=.*/CONFIG_NTP_MODE=0/' /boot/dietpi.txt
 
 # copy the blocklisting code from Ramon Kolb's install-docker.sh script
 # DOCKER-INSTALL.SH -- Installation script for the Docker infrastructure on a Raspbian or Ubuntu system

--- a/src/variants/iob-dietpi/dietpi.txt
+++ b/src/variants/iob-dietpi/dietpi.txt
@@ -207,7 +207,7 @@ CONFIG_CHECK_DIETPI_UPDATES=1
 CONFIG_CHECK_APT_UPDATES=1
 
 # Network time sync: 0=disabled | 1=boot only | 2=boot + daily | 3=boot + hourly | 4=Daemon + Drift
-CONFIG_NTP_MODE=0
+CONFIG_NTP_MODE=1
 
 # Serial Console: Set to 0 if you do not require serial console.
 CONFIG_SERIAL_CONSOLE_ENABLE=0


### PR DESCRIPTION
dietpi first boot with NTP=0 seems broken, work around it.

set NTP=1 in dietpi.txt
set NTP=0 using sed when chrony is installed