### PR TITLE
bugfix: populate missing config.json from .env

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -28,12 +28,6 @@ from utils.config import (
     write_values_to_env_file,
 )
 
-if not os.path.exists("/opt/adsb/config/config.json"):
-    # this must be either a first run after an install,
-    # or the first run after an upgrade from a version that didn't use the config.json
-    values = read_values_from_env_file()
-    write_values_to_config_json(values)
-
 # nofmt: on
 # isort: off
 from flask import (

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/config.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/config.py
@@ -1,4 +1,5 @@
 import json
+import os
 from .util import print_err
 
 
@@ -9,6 +10,13 @@ JSON_FILE_PATH = "/opt/adsb/config/config.json"
 
 def read_values_from_config_json():
     # print_err("reading .json file")
+    if not os.path.exists(JSON_FILE_PATH):
+        # this must be either a first run after an install,
+        # or the first run after an upgrade from a version that didn't use the config.json
+        print_err("WARNING: config.json doesn't exist, populating from .env")
+        values = read_values_from_env_file()
+        write_values_to_config_json(values)
+
     ret = {}
     try:
         ret = json.load(open(JSON_FILE_PATH, "r"))


### PR DESCRIPTION
Scenario: config.json is missing, .env has valid values Data is being initialized when importing anything from utils due to utils/__init__.py
Any Env instantiation tries and fails to read the json. Assigning any Env an value though will write to the json creating a nearly empty one.
This Env value assignment happens when the container versions are initialized and set to values during the Data initialization. This writes the json before app.py even has a chance to detect config.json is missing.
(read_values_from_env_file is imported before the config.json path is
 checked which loads Data)

Fix this by nesting the config.json initial population into the function which reads the config.json