### PR TITLE
fixup rbfeeder fake cpuinfo being a directory

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/config.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/config.py
@@ -46,6 +46,10 @@ def read_values_from_env_file():
         print_err("Failed to read .env file")
     return ret
 
+def escape_env(line):
+    # docker compose does weird stuff if there are $ in the env vars
+    # escape them using $$
+    return line.replace('$', '$$')
 
 def write_values_to_env_file(values):
     # print_err("writing .env file")
@@ -60,10 +64,12 @@ def write_values_to_env_file(values):
                 for i in range(len(value)):
                     suffix = "" if i == 0 else f"_{i}"
                     env_line = f"{key}{suffix}={value[i]}\n"
+                    env_line = escape_env(env_line)
                     f.write(env_line)
                     print_err(f"wrote {env_line.strip()} to .env")
             else:
                 env_line = f"{key}={value.strip() if type(value) == str else value}\n"
+                env_line = escape_env(env_line)
                 f.write(env_line)
                 print_err(f"wrote {env_line.strip()} to .env")
     # write the user env in the form that can be easily inserted into the yml file

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
@@ -108,6 +108,13 @@ def create_fake_RB_info():
     # let's just make sure the fake files are there and move on
     os.makedirs("/opt/adsb/rb/thermal_zone0", exist_ok=True)
     cpuinfo = pathlib.Path("/opt/adsb/rb/cpuinfo")
+    # when docker tries to mount this file without it existing, it creates a directory
+    # in case that has happened, remove it
+    if cpuinfo.is_dir():
+        try:
+            cpuinfo.rmdir()
+        except:
+            pass
     if not cpuinfo.exists():
         with open("/proc/cpuinfo", "r") as ci_in, open(cpuinfo, "w") as ci_out:
             for line in ci_in:


### PR DESCRIPTION
when docker tries to mount the cpuinfo file without it existing, it creates a directory
in case that has happened, remove it