### PR TITLE
data sharing: docker compose if "request key" is used in UI

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -1712,6 +1712,11 @@ class AdsbIm:
                     if not is_successful:
                         print_err(f"did not successfully enable {base}")
 
+                    # immediately start the containers in case the user doesn't click "i'm done here" after requesting a key
+                    seen_go = True
+                    # go back to the page we were on after applying settings
+                    self._next_url_from_director = request.url
+
                 continue
             # now handle other form input
             if key == "clear_range" and value == "1":


### PR DESCRIPTION
If the user requests a key on the data sharing page and that request is successful, the key is saved to the configuration but the settings aren't applied until the user clicks 'i'm done here'.

Fix that by setting seen_go whenever a key is requested. When saving values to the configuration, those values should also be applied via docker compose.