### PR TITLE
microproxy IP: allow full readsb net connector triplet

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/stage2.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/stage2.html
@@ -142,7 +142,7 @@
         </div>
         <div class="col-12 col-sm-7 col-md-8 col-lg-9 mb-3">
           <input type="text" id="add_micro_feeder_ip" name="add_micro_feeder_ip" required placeholder="1.2.3.4"
-                 class="form-control" pattern="((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])"
+                 class="form-control"
                  title="valid IPv4 address" />
         </div>
         <div id="mf_step1" class="col-12">

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
@@ -127,3 +127,17 @@ def create_fake_info():
         with open("/opt/adsb/rb/thermal_zone0/temp", "w") as fake_temp:
             print("12345\n", file=fake_temp)
     return not pathlib.Path("/sys/class/thermal/thermal_zone0/temp").exists()
+
+
+def mf_get_ip_and_triplet(ip):
+    # mf_ip for microproxies can either be an IP or a triplet of ip,port,protocol
+    split = ip.split(",")
+    if (len(split) != 1):
+        # the function was passed a triplet, set the ip to the first part
+        triplet = ip
+        ip = split[0]
+    else:
+        # the fucntion was passed an IP, port 30005 and protocol beast_in are implied
+        triplet = f"{ip},30005,beast_in"
+
+    return (ip, triplet)

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/stage2.yml
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/stage2.yml
@@ -21,7 +21,6 @@ services:
       #
       # --------------------------------------------------
       # readsb/decoder parameters:
-      - BEASTHOST=${AF_MICRO_IP_STAGE2NUM}
       - READSB_LAT=${FEEDER_LAT_STAGE2NUM}
       - READSB_LON=${FEEDER_LONG_STAGE2NUM}
       - READSB_ALT=${FEEDER_ALT_M_STAGE2NUM}


### PR DESCRIPTION
nonstandard beast ports / planefinder boxes / radarcape boxes can't currently be used as data sources for stage2

change that by allowing mf_ip to be the full readsb net connector triplet
only the IP also continues to be supported