### PR TITLE
disable other aggregators for the combined data of stage2

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -1337,13 +1337,17 @@ class AdsbIm:
             if not self._d.env_by_tags("ultrafeeder_uuid").list_get(sitenum):
                 self._d.env_by_tags("ultrafeeder_uuid").list_set(sitenum, str(uuid4()))
 
-            # disable other aggregators if their key isn't set:
-
             for agg in [
                 submit_key.replace("--submit", "")
                 for submit_key in self._other_aggregators.keys()
             ]:
                 if self._d.env_by_tags([agg, "is_enabled"]).list_get(sitenum):
+                    # disable other aggregators for the combined data of stage2
+                    if sitenum == 0 and self._d.is_enabled("stage2"):
+                        self._d.env_by_tags([agg, "is_enabled"]).list_set(
+                            sitenum, False
+                        )
+                    # disable other aggregators if their key isn't set
                     if self._d.env_by_tags([agg, "key"]).list_get(sitenum) == "":
                         print_err(
                             f"empty key, disabling: agg: {agg}, sitenum: {sitenum}"

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
@@ -172,7 +172,11 @@ class Data:
         Env("FEEDER_UNUSED_SERIAL_3", tags=["other-3"]),
         #
         # Ultrafeeder config, used for all 4 types of Ultrafeeder instances
-        Env("FEEDER_ULTRAFEEDER_CONFIG", tags=["ultrafeeder_config"]),
+        Env(
+            "FEEDER_ULTRAFEEDER_CONFIG",
+            default=[""],
+            tags=["ultrafeeder_config"]
+        ),
         Env("ADSBLOL_UUID", default=[""], tags=["adsblol_uuid"]),
         Env("ADSBLOL_LINK", default=[""], tags=["adsblol_link"]),
         Env("ULTRAFEEDER_UUID", default=[""], tags=["ultrafeeder_uuid"]),


### PR DESCRIPTION
It was possible to feed aggregators with combined data when enabling the feed to them and then switching the install to stage2.
Fix that by explicitely disabling that.

Also clean up a small log bit on first startup with the ultrafeeder config variable by setting a sensible default.