### PR TITLE
improve image pruning

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/docker-update-adsb-im
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/docker-update-adsb-im
@@ -25,18 +25,25 @@ bash /opt/adsb/docker-compose-start
 # alert: the following code relies on non quoted bash expansion
 PRUNE_LIST=$( \
     docker images -a --format "{{.Repository}}:{{.Tag}}" \
-    | grep -F -v \
-        $(docker ps -a --format '{{.Image}}' | while read line; do echo -n " -e $line"; done) \
-        $(cut -d= -f2 /opt/adsb/docker.image.versions | while read line; do echo -n " -e $line"; done) \
+    | grep -F -v -e '<none>' \
+        -f <(docker ps -a --format '{{.Image}}') \
+        -f <(cut -d= -f2 /opt/adsb/docker.image.versions) \
 )
 if ! [ -f os.adsb.feeder.image ]; then
     # if running as an app, restrict pruned images to images used by adsb.im
-    PRUNE_LIST=$( \
+    PRUNE_LIST=$( echo "$PRUNE_LIST" |
         grep -F -e dozzle -e alpine \
-            $(cut -d= -f2 /opt/adsb/docker.image.versions | cut -d: -f1 | while read line; do echo -n " -e $line"; done) \
-            <<< "$PRUNE_LIST" \
+            -f <(cut -d= -f2 /opt/adsb/docker.image.versions | cut -d: -f1) \
     )
 fi
+# remove images we use that don't have a tag:
+PRUNE_LIST_NOTAG=$(docker images -a \
+        | grep -F -e dozzle -e alpine -f <(cut -d= -f2 /opt/adsb/docker.image.versions | cut -d: -f1) \
+        | awk '{ if ($2 == "<none>") print $3 }' \
+)
+
+# combine variables preserving newlines:
+PRUNE_LIST=$(echo "$PRUNE_LIST"; echo "$PRUNE_LIST_NOTAG")
 
 # then all images on this prune list are deleted
 if [[ -n "$PRUNE_LIST" ]]; then
@@ -49,4 +56,4 @@ echo "PRUNING DONE"
 
 sed -i "s/CONTAINER_VERSION=.*/CONTAINER_VERSION=$TIME/" /opt/adsb/config/.env
 
-echo "$(date -Iseconds): done" >> /opt/adsb/adsb-setup.log
+echo "$(date -Iseconds): done"


### PR DESCRIPTION
prune container images used by adsb.im that don't have a tag

use grep -f instead of previous code