### PR TITLE
eliminate need for python semver package

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
@@ -567,6 +567,7 @@ class Data:
         ),
         Env("AF_MICRO_IP", default=[""], tags=["mf_ip"]),
         Env("AF_MICRO_BROFM", default=[False], tags=["mf_brofm", "is_enabled"]),
+        Env("AF_MICRO_BROFM_CAPABLE", default=[False], tags=["mf_brofm_capable", "is_enabled"]),
         Env("AF_FEEDER_VERSION", default=[""], tags=["mf_version"]),
     }
 


### PR DESCRIPTION
just let the microfeeder tell us if it's brofm capable or not

this has the nice side effect from enforcing the remote site to be configured as a microfeeder
while this isn't guaranteed to stay this way ... best effort and all