### PR TITLE
Captive portal POST handling fix

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/accesspoint/dhcpd.conf
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/accesspoint/dhcpd.conf
@@ -1,5 +1,8 @@
 option domain-name "adsb-feeder.im";
 option domain-name-servers 192.168.199.1;
+# Captive-portal identification as in RFC 7710.
+option captive-portal code 160 = text;
+option captive-portal "http://192.168.199.1/";
 
 default-lease-time 600;
 max-lease-time 7200;


### PR DESCRIPTION
This is a fix for an issue with the captive portal, which can seemingly randomly vanish when unrelated `POST` requests arrive. Since the fake DNS attracts all traffic, the hotspot API gets unrelated requests, e.g. from phone apps in the background (WhatsApp likes to `POST` to `whatsapp.com/chat`, apparently). Any `POST` request, no matter what it contains, will shut down the hotspot and disconnect the user.

This PR fixes that by only checking new wifi credentials if the request actually contains `ssid` and `passwd`.

It also sets DHCP option 160, which [RFC 7710](https://datatracker.ietf.org/doc/html/rfc7710) defines for captive portal URIs. That may help with detection in some cases ([comitup uses this](https://github.com/davesteele/comitup/issues/208#issuecomment-1170660981), and that works really well as an AP).