### PR TITLE
Update container action buttons to reflect selection

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/index.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/index.html
@@ -240,7 +240,7 @@
       <span id="advice" class="small">&nbsp;</span>
     </div>
     <div id="update_buttons" class="text-secondary">
-      <h5 class="mt-1">Update feeder applications</h5>
+      <h5 class="mt-1">Update Feeder Software</h5>
       <form method="POST" onsubmit="show_spinner(); return true;">
         <label for="update_feeder_aps">
           Update the web UI, setup apps, and containers to the latest beta or stable version.

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/setup.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/setup.html
@@ -172,7 +172,7 @@
   </div>
   <br>
   <div class="form-group">
-    <button type="submit" name="submit" value="go" class="btn btn-primary">Submit</button>
+    <button type="submit" name="submit" value="go" class="btn btn-primary btn-rounded btn-block btn-lg p-4 mb-3">Submit</button>
   </div>
   <p>{{ message }}</p>
 </form>

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/systemmgmt.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/systemmgmt.html
@@ -202,7 +202,6 @@
         <div class="col-12">
           <label for="restart_containers">Typically this shouldn't be necessary, but occasionally it
             seems that for whatever reason a container doesn't pick up a setting or gets otherwise stuck.
-            <br>Not selecting any containers means that the action will be performed for all containers.
           </label>
         </div>
         <div class="row align-items-center">
@@ -217,9 +216,9 @@
           <div class="col-4">
             <div class="row align-items-center">
               <button type="submit" class="mb-3 btn btn-primary mx-auto w-100" name="restart_containers"
-                      value="go">Restart Containers</button>
+                      value="go" id="restart_button">Restart All</button>
               <button type="submit" class="mb-3 btn btn-primary mx-auto w-100" name="recreate_containers"
-                      value="go">Recreate Containers</button>
+                      value="go" id="recreate_button">Recreate All</button>
             </div>
           </div>
         </div>
@@ -357,6 +356,31 @@
     if (data["main_changelog"]) {
         $("#update_feeder_aps_stable").attr("title", data["main_changelog"]);
     }
+  });
+
+  // Update button text based on container selection
+  function updateContainerButtonText() {
+    const checkboxes = document.querySelectorAll('input[type="checkbox"][name^="restart-"]');
+    const restartButton = document.getElementById('restart_button');
+    const recreateButton = document.getElementById('recreate_button');
+    
+    const checkedCount = Array.from(checkboxes).filter(cb => cb.checked).length;
+    
+    if (checkedCount === 0) {
+      restartButton.textContent = 'Restart All';
+      recreateButton.textContent = 'Recreate All';
+    } else {
+      restartButton.textContent = 'Restart Selected (' + checkedCount + ')';
+      recreateButton.textContent = 'Recreate Selected (' + checkedCount + ')';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const checkboxes = document.querySelectorAll('input[type="checkbox"][name^="restart-"]');
+    checkboxes.forEach(checkbox => {
+      checkbox.addEventListener('change', updateContainerButtonText);
+    });
+    updateContainerButtonText();
   });
 </script>
 {% endblock %}

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/systemmgmt.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/systemmgmt.html
@@ -166,11 +166,11 @@
     </form>
   </div>
   <div class="col-12 col-lg-6">
-    <h5 class="mt-3">Update Feeder Applications</h5>
+    <h5 class="mt-3">Update Feeder Software</h5>
     <form method="POST" onsubmit="show_spinner(); return true;">
       <div class="row align-items-center">
         <div class="col-8">
-          <label for="update_feeder_aps">Update to the current ADS-B feeder applications (i.e. the
+          <label for="update_feeder_aps">Update to the current ADS-B feeder software (i.e. the
             web UI, setup apps, and containers). Either the latest beta or stable version.
             {% if channel != "" %} Additionally, you can try to update to the latest state of the {{ channel }}
             branch. This is typically far less tested and may not work at all. Please make sure to create a


### PR DESCRIPTION
Less explainer text = more welcoming and simple UX for new users

It is better to *show* the user what would happen when they click the buttons, rather than *tell*.

<img width="243" alt="adsb_container_actions" src="https://github.com/user-attachments/assets/840153b6-1a9b-4615-880b-d30f3401171c" />