### PR TITLE
Replace /usr/bin/bash with /bin/bash

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -548,7 +548,7 @@ class AdsbIm:
         host_name = self.onlyAlphaNumDash(site_name)
 
         def start_mdns():
-            subprocess.run(["/usr/bin/bash", "/opt/adsb/scripts/mdns-alias-setup.sh", f"{host_name}"])
+            subprocess.run(["/bin/bash", "/opt/adsb/scripts/mdns-alias-setup.sh", f"{host_name}"])
             subprocess.run(["/usr/bin/hostnamectl", "hostname", f"{host_name}"])
 
         if not host_name or self._current_site_name == site_name:

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/app-uninstall
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/app-uninstall
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # Helper functions
 exit_with_message() { echo "$1"; exit; }

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-bootstrap.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-bootstrap.service
@@ -6,7 +6,7 @@ After=network-online.target adsb-hotspot.service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/opt/adsb
-ExecStart=/usr/bin/bash /opt/adsb/bootstrap.sh
+ExecStart=/bin/bash /opt/adsb/bootstrap.sh
 TimeoutStartSec=0
 SyslogIdentifier=adsb-bootstrap
 

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-docker.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-docker.service
@@ -6,8 +6,8 @@ PartOf=docker.service
 [Service]
 SyslogIdentifier=adsb-docker
 WorkingDirectory=/opt/adsb
-ExecStartPre=-/usr/bin/bash -c "mount -o remount,exec,size=$(( $(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*') / 2 ))k /run"
-ExecStartPre=-/usr/bin/bash -c "[[ -f /opt/adsb/os.adsb.feeder.image ]] && echo 128 > /sys/module/usbcore/parameters/usbfs_memory_mb"
+ExecStartPre=-/bin/bash -c "mount -o remount,exec,size=$(( $(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*') / 2 ))k /run"
+ExecStartPre=-/bin/bash -c "[[ -f /opt/adsb/os.adsb.feeder.image ]] && echo 128 > /sys/module/usbcore/parameters/usbfs_memory_mb"
 ExecStartPre=-/opt/adsb/scripts/fix-docker-network
 ExecStartPre=-/opt/adsb/scripts/disk-to-run.sh
 ExecStart=/opt/adsb/docker-compose-start

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-feeder-update.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-feeder-update.service
@@ -9,7 +9,7 @@ Description=ADS-B Feeder Update Service
 Type=oneshot
 RemainAfterExit=no
 WorkingDirectory=/opt/adsb
-ExecStart=/usr/bin/bash /opt/adsb/feeder-update -wait
+ExecStart=/bin/bash /opt/adsb/feeder-update -wait
 TimeoutStartSec=0
 SyslogIdentifier=adsb-feeder-update
 

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-hotspot.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-hotspot.service
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=oneshot
 WorkingDirectory=/opt/adsb
-ExecStart=/usr/bin/bash /opt/adsb/scripts/net-or-hotspot.sh
+ExecStart=/bin/bash /opt/adsb/scripts/net-or-hotspot.sh
 SyslogIdentifier=adsb-hotspot
 
 [Install]

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-nonimage.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-nonimage.service
@@ -4,6 +4,6 @@ Description=ADS-B Feeder Dummy service
 [Service]
 Type=oneshot
 WorkingDirectory=/opt/adsb
-ExecStart=/usr/bin/bash -c "exit 0"
+ExecStart=/bin/bash -c "exit 0"
 TimeoutStartSec=0
 

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-setup.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-setup.service
@@ -5,7 +5,7 @@ After=network-online.target adsb-hotspot.service
 [Service]
 SyslogIdentifier=adsb-setup
 WorkingDirectory=/opt/adsb/adsb-setup
-ExecStartPre=/usr/bin/bash /opt/adsb/pre-start.sh
+ExecStartPre=/bin/bash /opt/adsb/pre-start.sh
 ExecStart=/usr/bin/python3 /opt/adsb/adsb-setup/app.py
 ExecStopPost=/opt/adsb/scripts/log2disk.sh
 Restart=always

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-update.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-update.service
@@ -4,6 +4,6 @@ Description=ADS-B Feeder Image Update Service
 
 [Service]
 WorkingDirectory=/opt/adsb
-ExecStart=/usr/bin/bash /opt/adsb/scripts/update-checks-adsb-im
+ExecStart=/bin/bash /opt/adsb/scripts/update-checks-adsb-im
 SyslogIdentifier=adsb-update
 

--- a/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-zram.service
+++ b/src/modules/adsb-feeder/filesystem/root/usr/lib/systemd/system/adsb-zram.service
@@ -5,7 +5,7 @@ Description=ADS-B Feeder Zram Service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/opt/adsb
-ExecStart=/usr/bin/bash /opt/adsb/scripts/zram-swap.sh
+ExecStart=/bin/bash /opt/adsb/scripts/zram-swap.sh
 TimeoutStartSec=0
 SyslogIdentifier=adsb-zram
 


### PR DESCRIPTION
On distro versions which have no usr-merged directories, `/usr/bin/bash` does usually not exist. `/bin/bash` exists in these cases, as well as on usr-merged distros via symlink. And the `/bin => /usr/bin` symlink is not expected to be removed in time soon.

A failsafe but more complex alternative would be `/usr/bin/env bash`, to support any bash path.

Found while implementing some automated installation tests. Our Bullseye container images are not usr-merged, AFAIK `debootstrap` does this for Bookworm and later only, which is also the first Debian version to pull `usrmerge` (or `usr-is-merged`) package as core dependency. And the native path of `bash` is `/usr/bin/bash` in Debian Trixie for the first time.