### PR TITLE
Switch healthcheck requests to POST with payload

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/expert.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/expert.html
@@ -1007,18 +1007,18 @@
             considered healthy.
             <br>
             If the system is at any point considered unhealthy for more than 5 minutes, a simple http
-            POST request will  be performed using with /fail added to the URL and the reason for the
-            failure will be displayed on the Feeder Homepage and passed as a body to the URL.
+            POST request will  be performed with /fail added to the URL. The reason for the
+            failure will be displayed on the Feeder Homepage and passed as a body in the POST request.
             <br>
             Health status will not include feeds as that is pretty much always not an issue on the
-            receiver side but rather an issue with the aggregator.
-            (possibly adding bad MLAT sync in the future)
+            receiver side but rather an issue with the aggregator
+            (bad MLAT sync may be added in the future).
             <br>
             No planes / messages for a configurable period of time will mean the system is considered
-            unhealthy.  The default is 24 hours but if you have traffic around the clock this can
+            unhealthy. The default is 24 hours but if you have traffic around the clock this can
             safely be reduced to 1 or 2 hours.
             <br>
-            Decoder failures will mean the system is considered unhealthy. (1090 + 978 only)
+            Decoder failures will mean the system is considered unhealthy (1090 + 978 only).
           </div>
         </div>
         <div class="col-4 mb-1">

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/expert.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/expert.html
@@ -1003,12 +1003,12 @@
             <br>
             Set empty URL to disable.
             <br>
-            Every 60 minutes a simple http GET request will be performed on this URL if the system is
+            Every 60 minutes a simple http POST request will be performed on this URL if the system is
             considered healthy.
             <br>
             If the system is at any point considered unhealthy for more than 5 minutes, a simple http
-            GET request will  be performed using with /fail added to the URL and the reason for the
-            failure will be displayed on the Feeder Homepage.
+            POST request will  be performed using with /fail added to the URL and the reason for the
+            failure will be displayed on the Feeder Homepage and passed as a body to the URL.
             <br>
             Health status will not include feeds as that is pretty much always not an issue on the
             receiver side but rather an issue with the aggregator.

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/agg_status.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/agg_status.py
@@ -547,7 +547,7 @@ class Healthcheck:
             self.nextGoodPing = time.time() + self.pingInterval
             self.nextFailPing = time.time() # set next fail ping to be immediate
             if self._d.env_by_tags("healthcheck_url").value:
-                page, status = get_plain_url(self._d.env_by_tags("healthcheck_url").value)
+                page, status = get_plain_url(self._d.env_by_tags("healthcheck_url").value, method="POST")
                 if status != 200:
                     print_err(f"healthcheck url ping FAILURE: got http status {status}")
                     # failure, try again in a minute instead of waiting pingInterval
@@ -568,7 +568,9 @@ class Healthcheck:
             self.nextFailPing = time.time() + self.pingInterval
             self.nextGoodPing = time.time() # set next success ping to be immediate
             if self._d.env_by_tags("healthcheck_url").value:
-                page, status = get_plain_url(self._d.env_by_tags("healthcheck_url").value + "/fail")
+                fail_url = self._d.env_by_tags("healthcheck_url").value + "/fail"
+                payload = self.reason if self.reason else ""
+                page, status = get_plain_url(fail_url, method="POST", data=payload)
                 if status != 200:
                     print_err(f"healthcheck url fail FAILURE: got http status {status}")
                     # failure, try again in a minute instead of waiting pingInterval

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
@@ -213,22 +213,29 @@ def string2file(path=None, string=None, verbose=False):
             print_err(f'wrote "{string}" to {path}')
 
 
-def get_plain_url(plain_url):
+def get_plain_url(plain_url, method="GET", data=None):
     requests.packages.urllib3.util.connection.HAS_IPV6 = False
     status = -1
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+    }
+    method = method.upper()
+    if data is not None:
+        # sending plain text for custom bodies
+        headers["Content-Type"] = "text/plain; charset=utf-8"
     try:
-        response = requests.get(
-            plain_url,
-            headers={
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.5",
-                "Upgrade-Insecure-Requests": "1",
-                "Sec-Fetch-Dest": "document",
-                "Sec-Fetch-Mode": "navigate",
-                "Sec-Fetch-Site": "none",
-                "Sec-Fetch-User": "?1",
-            },
+        response = requests.request(
+            method=method,
+            url=plain_url,
+            headers=headers,
+            data=data
         )
     except (
         requests.HTTPError,


### PR DESCRIPTION
I've updated the healthcheck functionality to pass the reason for a failed healthcheck as part of the body of the request to make it possible to see the cause of the failure without having to access the feeder, as shown below.


<img height="300" alt="healthchecks_example" src="https://github.com/user-attachments/assets/c59b4600-8e77-4505-be6a-c21bbbf8de76" />


To do this, I had to make the failure pings use POST instead of GET. Although not necessary, for the sake of consistency, I did the same thing for the success pings.
