### PR TITLE
Consistent wording for applying settings

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/advanced.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/advanced.html
@@ -38,7 +38,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="css_theme--submit"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
       </div>
     </form>
@@ -187,7 +187,7 @@
                   value="go">Disable</button>
         </div>
         <div class="col-3 my-1">
-          <button type="submit" class="btn btn-primary mx-auto w-100" name="skystats--update" value="go">Update</button>
+          <button type="submit" class="btn btn-primary mx-auto w-100" name="skystats--update" value="go">Apply</button>
         </div>
         <div class="col-12 mb-2 mt-2">
           <span onclick="$('#skystats_advanced').toggleClass('d-none'); $(this).find('.toggle-icon').text($('#skystats_advanced').hasClass('d-none') ? '▶' : '▼'); return false;"
@@ -307,7 +307,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="healthcheck--submit"
-                  value="go">Update</button>
+                  value="go">Apply</button>
         </div>
         <div class="col-12 mb-2 mt-2">
           <span onclick="$('#healthcheck_explain').toggleClass('d-none'); $(this).find('.toggle-icon').text($('#healthcheck_explain').hasClass('d-none') ? '▶' : '▼'); return false;"
@@ -421,7 +421,7 @@
               </div>
               <div class="col-3 my-1">
                 <button type="submit" class="btn btn-primary mx-auto w-100" name="acarsdec--update"
-                        value="go">Update</button>
+                        value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="acars_feed_id">
@@ -492,7 +492,7 @@
               </div>
               <div class="col-3 my-1">
                 <button type="submit" class="btn btn-primary mx-auto w-100" name="acarsdec2--update"
-                        value="go">Update</button>
+                        value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="acars_2_feed_id">
@@ -551,7 +551,7 @@
               </div>
               <div class="col-3 my-1">
                 <button type="submit" class="btn btn-primary mx-auto w-100" name="dumpvdl2--update"
-                        value="go">Update</button>
+                        value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="vdl2_feed_id">
@@ -621,7 +621,7 @@
                         formnovalidate value="go">Disable</button>
               </div>
               <div class="col-3 my-1">
-                <button type="submit" class="btn btn-primary mx-auto w-100" name="dumphfdl--update" value="go">Update</button>
+                <button type="submit" class="btn btn-primary mx-auto w-100" name="dumphfdl--update" value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="hfdl_feed_id">
@@ -689,7 +689,7 @@
               </div>
               <div class="col-3 my-1">
                 <button type="submit" class="btn btn-primary mx-auto w-100" name="hfdlobserver--update"
-                        value="go">Update</button>
+                        value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="hfdl_feed_id">
@@ -800,7 +800,7 @@
               </div>
               <div class="col-3 my-1">
                 <button type="submit" class="btn btn-primary mx-auto w-100" name="shipfeeder--update"
-                        value="go">Update</button>
+                        value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="ais_station_name">
@@ -883,7 +883,7 @@
               </div>
               <div class="col-3 my-1">
                 <button type="submit" class="btn btn-primary mx-auto w-100" name="sonde--update"
-                        value="go">Update</button>
+                        value="go">Apply</button>
               </div>
               <div class="col-4 mb-1">
                 <label for="sonde_callsign">

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
@@ -23,7 +23,7 @@
 <form class="row gy-2 gx-3 mx-1 mx-lg-3 mx-xl-5 align-items-center" method="post"
       onsubmit="show_spinner(); return true;">
   <button type="submit" class="btn btn-primary btn-rounded  btn-block btn-lg p-4 mb-3" name="aggregators"
-          value={{go}}>apply settings - take me to the website</button>
+          value={{go}}>Apply</button>
 
   <!-- ADS-B related aggregators -->
   {% if is_enabled('base_config') and env_value_by_tag('aggregator_choice') in ['micro', 'nano'] %}
@@ -589,7 +589,7 @@
   <!-- end of the AIS section -->
 
   <button type="submit" class="btn btn-primary btn-rounded  btn-block btn-lg p-4 mb-3 my-5" name="aggregators"
-          value={{go}}>apply settings - take me to the website</button>
+          value={{go}}>Apply</button>
 </form>
 <script>
   const box_fields = [

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/expert.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/expert.html
@@ -35,7 +35,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="ultrafeeder_extra_args_microsites--submit"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
         <div class="col-12 mb-2">Stage2: applied to the ultrafeeder instance with combined data:</div>
         <div class="col-8">
@@ -44,7 +44,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="ultrafeeder_extra_args--submit"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
         {% else %}
         <div class="col-8">
@@ -53,7 +53,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="ultrafeeder_extra_args--submit"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
         {% endif %}
       </div>
@@ -79,7 +79,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="ultrafeeder_extra_env--submit"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
       </div>
     </form>
@@ -101,7 +101,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="tar1090_query_params--submit"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
       </div>
     </form>

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/setup.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/setup.html
@@ -157,7 +157,7 @@
   </div>
   <br>
   <div class="form-group">
-    <button type="submit" name="submit" value="go" class="btn btn-primary btn-rounded btn-block btn-lg p-4 mb-3">Submit</button>
+    <button type="submit" name="submit" value="go" class="btn btn-primary btn-rounded btn-block btn-lg p-4 mb-3">Apply</button>
   </div>
   <p>{{ message }}</p>
 </form>

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/systemmgmt.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/systemmgmt.html
@@ -30,7 +30,7 @@
                  required>
         </div>
         <div class="col-4">
-          <button type="submit" class="btn btn-primary mx-auto w-100" name="ssh" value="stay">Submit</button>
+          <button type="submit" class="btn btn-primary mx-auto w-100" name="ssh" value="stay">Apply</button>
         </div>
       </div>
     </form>
@@ -278,7 +278,7 @@
         </div>
         {% endif %}
         <div class="col-4">
-          <button type="submit" class="btn btn-primary mx-auto w-100" name="zerotier" value="go">Submit</button>
+          <button type="submit" class="btn btn-primary mx-auto w-100" name="zerotier" value="go">Apply</button>
         </div>
         {% if zerotier_running %}
         <div class="col-12 text-danger">
@@ -319,7 +319,7 @@
                  placeholder="Enter additional tailscale options you need">
         </div>
         <div class="col-4">
-          <button type="submit" class="btn btn-primary mx-auto w-100" name="tailscale" value="go">Submit</button>
+          <button type="submit" class="btn btn-primary mx-auto w-100" name="tailscale" value="go">Apply</button>
         </div>
         {% else %}
         <div class="col-8">
@@ -328,7 +328,7 @@
         </div>
         <div class="col-4">
           <button type="submit" class="btn btn-primary mx-auto w-100" name="tailscale_disable_go"
-                  value="go">Submit</button>
+                  value="go">Apply</button>
         </div>
         <div class="col-12 text-danger">
           This will prevent you from accessing this feeder if you use a Tailscale network to connect to it.
@@ -370,7 +370,7 @@
           <input class="form-control mx-auto w-100" id="wifi_password" name="wifi_password" type="text" placeholder="Password">
         </div>
         <div class="col-4">
-          <button type="submit" class="btn btn-primary mx-auto w-100" name="wifi" value="stay">Submit</button>
+          <button type="submit" class="btn btn-primary mx-auto w-100" name="wifi" value="stay">Apply</button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
This PR standardises the wording of the buttons that save settings as `Apply`

- `advanced.html` had the text as `Update` which was confusing especially as the word update is used elsewhere to mean update the software.
- The text `take me to the website` isn't really necessary on the `aggregators.html` page as there is no other option - all `apply settings` buttons take you to the feeder homepage.
- Wording was inconsistent elsewhere.

