### PR TITLE
Encourage feeding non-commerical aggregators

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
@@ -24,6 +24,10 @@
       onsubmit="show_spinner(); return true;">
   <button type="submit" class="btn btn-primary btn-rounded  btn-block btn-lg p-4 mb-3" name="aggregators"
           value={{go}}>Apply</button>
+  
+  <div class="col-12 alert alert-info mb-3">
+    <strong>Support the community!</strong> If you're not already, consider feeding at least one non-commercial aggregator (for example <i>adsb.lol, Fly Italy ADSB or TheAirTraffic</i>). Unlike commercial aggregators, they don't require accounts and keep their data freely open for everyone.
+  </div>
 
   <!-- ADS-B related aggregators -->
   {% if is_enabled('base_config') and env_value_by_tag('aggregator_choice') in ['micro', 'nano'] %}


### PR DESCRIPTION
No doubt many users just feed the commercial aggregators so that they can get their "free" premium accounts. This PR encourages users to feed some of the non-commerical ones. I know that when I started feeding ADSB data, I didn't know about or have any reason in mind to support these smaller aggregators.

Hopefully this gets more people to feed those sites. 