### PR TITLE
Update aggregator links to point to main sites

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
@@ -68,66 +68,65 @@
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--adsblol"
            id="is_enabled--adsblol" {{ uf_enabled("adsblol", m) }} onclick="$('#individual').click();" />
     <label for="is_enabled--adsblol">
-      <a href="https://adsb.lol/privacy-license/">adsb.lol</a>
+      <a href="https://adsb.lol/">adsb.lol</a> <a href="https://adsb.lol/privacy-license/" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--flyitaly"
            id="is_enabled--flyitaly" {{ uf_enabled("flyitaly", m) }}  onclick="$('#individual').click();" />
     <label for="is_enabled--flyitaly">
-      <a href="https://flyitalyadsb.com/informazioni-legali-e-privacy/">Fly Italy ADSB</a>
+      <a href="https://flyitalyadsb.com/">Fly Italy ADSB</a> <a href="https://flyitalyadsb.com/informazioni-legali-e-privacy/" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--avdelphi"
            id="is_enabled--avdelphi" {{ uf_enabled("avdelphi", m) }}  onclick="$('#individual').click();" />
     <label for="is_enabled--avdelphi">
-      <a href="https://www.avdelphi.com/privacy.html">AVDelphi</a>
+      <a href="https://www.avdelphi.com/">AVDelphi</a> <a href="https://www.avdelphi.com/privacy.html" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--planespotters"
            id="is_enabled--planespotters" {{ uf_enabled("planespotters", m) }}  onclick="$('#individual').click();" />
     <label for="is_enabled--planespotters">
-      <a href="https://www.planespotters.net/legal/privacypolicy/">planespotters.net</a>
+      <a href="https://www.planespotters.net/">planespotters.net</a> <a href="https://www.planespotters.net/legal/privacypolicy/" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" data-mdb-toggle="tooltip"
-           title="please note that this site is missing a clear data/privacy policy" name="is_enabled--ultrafeeder--tat"
+           title="This site is missing a clear data/privacy policy" name="is_enabled--ultrafeeder--tat"
            id="is_enabled--tat" {{ uf_enabled("tat", m) }} onclick="$('#individual').click();" />
     <label for="is_enabled--tat">
-      <a href="https://theairtraffic.com/privacy/">TheAirTraffic.com</a>
+      <a href="https://theairtraffic.com/">TheAirTraffic.com</a> <a href="https://theairtraffic.com/privacy/" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--adsbfi" id="is_enabled--adsbfi"
            {{ uf_enabled("adsbfi", m) }} onclick="$('#individual').click();" />
     <label for="is_enabled--adsbfi">
-      <a href="https://adsb.fi/privacy">adsb.fi</a>
+      <a href="https://adsb.fi/">adsb.fi</a> <a href="https://adsb.fi/privacy" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder no_privacy" data-mdb-toggle="tooltip"
-           title="please note that this site is missing a clear data/privacy policy"
+           title="This site is missing a clear data/privacy policy"
            name="is_enabled--ultrafeeder--hpradar" id="is_enabled--hpradar" {{ uf_enabled("hpradar", m) }} onclick="$('#individual').click();" />
     <label for="is_enabled--hpradar">
-      <a href="https://skylink.hpradar.com/" data-mdb-toggle="tooltip"
-         title="please note that this site is missing a clear data/privacy policy">HPRadar</a>
+      <a href="https://skylink.hpradar.com/">HPRadar</a> <span title="This site is missing a clear data/privacy policy" style="font-size: 0.8em;">⚠️</span>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--alive" id="is_enabled--alive"
            {{ uf_enabled("alive", m) }} onclick="$('#individual').click();"/>
     <label for="is_enabled--alive">
-      <a href="https://airplanes.live/privacy">airplanes.live</a>
+      <a href="https://airplanes.live/">airplanes.live</a> <a href="https://airplanes.live/privacy" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--adsbx" id="is_enabled--adsbx"
            {{ uf_enabled("adsbx", m) }} onclick="$('#individual').click();" />
     <label for="is_enabled--adsbx">
-      <a href="https://www.adsbexchange.com/privacy-policy/">ADSBExchange</a>
+      <a href="https://www.adsbexchange.com/">ADSBExchange</a> <a href="https://www.adsbexchange.com/privacy-policy/" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
     </label>
   </div>
   <div class="col-12 form-check text-end">
@@ -150,7 +149,7 @@
     <input type="checkbox" class="form-check-input me-1" name="flightradar--is_enabled" id="flightradar--is_enabled"
            {{ others_enabled("flightradar", m) }} />
     <label class="mx-1 w-auto" for="flightradar--is_enabled">
-      <a href="https://www.flightradar24.com/privacy-policy">flightradar24</a>
+      <a href="https://www.flightradar24.com/">flightradar24</a> <a href="https://www.flightradar24.com/privacy-policy" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
       <div class="form-group" id="FR_FIELDS">
         <label for="flightradar--key">
           {% if not list_is_enabled('uat978',m) %}
@@ -179,8 +178,7 @@
     <input type="checkbox" class="form-check-input me-1" name="planewatch--is_enabled" id="planewatch--is_enabled"
            {{ others_enabled("planewatch", m) }} />
     <label class="mx-1 w-auto" for="planewatch--is_enabled">
-      <a href="https://plane.watch" data-mdb-toggle="tooltip"
-         title="please note that this site is missing a clear data/privacy policy">Plane.watch</a>
+      <a href="https://plane.watch">Plane.watch</a> <span title="This site is missing a clear data/privacy policy" style="font-size: 0.8em;">⚠️</span>
       <div class="form-group" id="PW_FIELDS">
         <label for="planewatch--key">
           To sign up for an API key go to <a href="https://atc.plane.watch/">atc.plane.watch</a>, sign up for an
@@ -196,8 +194,8 @@
   <div class="ol-12 form-check">
     <input type="checkbox" class="form-check-input me-1" name="flightaware--is_enabled" id="flightaware--is_enabled"
            {{ others_enabled("flightaware", m) }} />
-    <label class="mx-1 w-auto" for="FA">
-      <a href="https://www.flightaware.com/about/privacy/">FlightAware</a>
+    <label class="mx-1 w-auto" for="flightaware--is_enabled">
+      <a href="https://www.flightaware.com/">FlightAware</a> <a href="https://www.flightaware.com/about/privacy/" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
       <div class="form-group" id="FA_FIELDS">
         <label for="flightaware--key">
           You need a FlightAware / Piaware feeder ID. If you already have one, please enter it below. Otherwise, leave
@@ -221,8 +219,8 @@
     <input type="checkbox" class="form-check-input me-1" name="radarbox--is_enabled" id="radarbox--is_enabled"
            {{ others_enabled("radarbox", m) }} />
     <label class="mx-1 w-auto" for="radarbox--is_enabled">
-      <a href="https://www.airnavradar.com/terms-of-use" data-mdb-toggle="tooltip"
-         title="please note that this site is missing a clear data/privacy policy">AirNav Radar</a>
+      <a href="https://www.airnavradar.com/" data-mdb-toggle="tooltip"
+         title="This site is missing a clear data/privacy policy">AirNav Radar</a> <a href="https://www.airnavradar.com/privacy-policy" title="Terms of Use" style="font-size: 0.8em;">🔒</a>
       <div class="form-group" id="RB_FIELDS">
         <label for="radarbox--key">
           You need a AirNav Radar (formerly RadarBox) sharing key. If you already have one, please enter it below. Otherwise,
@@ -241,7 +239,7 @@
     <input type="checkbox" class="form-check-input me-1" name="planefinder--is_enabled" id="planefinder--is_enabled"
            {{ others_enabled("planefinder", m) }} />
     <label class="mx-1 w-auto" for="planefinder--is_enabled">
-      <a href="https://planefinder.net/legal/privacy-information-notice">PlaneFinder</a>
+      <a href="https://planefinder.net/">PlaneFinder</a> <a href="https://planefinder.net/legal/privacy-information-notice" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
       <div class="form-group" id="PF_FIELDS">
         <label for="planefinder--key">
           You need a PlaneFinder sharecode. If you already have one, please enter it below. Otherwise, request a
@@ -258,7 +256,7 @@
     <input type="checkbox" class="form-check-input me-1" name="adsbhub--is_enabled" id="adsbhub--is_enabled"
            {{ others_enabled("adsbhub", m) }} />
     <label class="mx-1 w-auto" for="adsbhub--is_enabled">
-      <a href="https://www.adsbhub.org/privacy-policy.php">ADSBHub</a>
+      <a href="https://www.adsbhub.org/">ADSBHub</a> <a href="https://www.adsbhub.org/privacy-policy.php" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
       <div class="form-group" id="AH_FIELDS">
         <label for="adsbhub--key">
           To sign up for an ADSBHub station key go to
@@ -276,7 +274,7 @@
     <input type="checkbox" class="form-check-input me-1" name="opensky--is_enabled" id="opensky--is_enabled"
            {{ others_enabled("opensky", m) }} />
     <label class="mx-1 w-auto" for="opensky--is_enabled">
-      <a href="https://opensky-network.org/about/privacy-policy">OpenSky Network</a>
+      <a href="https://opensky-network.org/">OpenSky Network</a> <a href="https://opensky-network.org/about/privacy-policy" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
       <!-- this one needs automation set up with a docker container again -- and it needs two fields -->
       <div class="form-group" id="OS_FIELDS">
         <label for="opensky--key">
@@ -298,8 +296,7 @@
     <input type="checkbox" class="form-check-input me-1" name="radarvirtuel--is_enabled" id="radarvirtuel--is_enabled"
            {{ others_enabled("radarvirtuel", m) }} />
     <label class="mx-1 w-auto" for="radarvirtuel--is_enabled">
-      <a href="https://www.radarvirtuel.com/" data-mdb-toggle="tooltip"
-         title="please note that this site is missing a clear data/privacy policy">RadarVirtuel</a>
+      <a href="https://www.radarvirtuel.com/">RadarVirtuel</a> <span title="This site is missing a clear data/privacy policy" style="font-size: 0.8em;">⚠️</span>
       <div class="form-group" id="RV_FIELDS">
         <label for="radarvirtuel--key">
           To sign up for a feeder key send email to
@@ -317,7 +314,7 @@
     <input type="checkbox" class="form-check-input me-1" name="1090uk--is_enabled" id="1090uk--is_enabled"
            {{ others_enabled("1090uk", m) }} />
     <label class="mx-1 w-auto" for="1090uk--is_enabled">
-      <a href="https://1090mhz.uk/legal.html#privacy">1090MHz UK</a>
+      <a href="https://1090mhz.uk/">1090MHz UK</a> <a href="https://1090mhz.uk/legal.html#privacy" title="Privacy Policy" style="font-size: 0.8em;">🔒</a>
       <div class="form-group" id="TNUK_FIELDS">
         <label for="1090uk--key">
           1090MHz UK is only interested in the UK and surrounding countries out to 1000nm including Ireland, Jersey,
@@ -334,7 +331,7 @@
     <input type="checkbox" class="form-check-input me-1" name="sdrmap--is_enabled" id="sdrmap--is_enabled"
            {{ others_enabled("sdrmap", m) }} />
     <label class="mx-1 w-auto" for="sdrmap--is_enabled">
-      <a href="https://sdrmap.org/">sdrmap</a>
+      <a href="https://sdrmap.org/">sdrmap</a> <span title="This site is missing a clear data/privacy policy" style="font-size: 0.8em;">⚠️</span>
       <div class="form-group" id="SM_FIELDS">
         <label for="sdrmap--user">
           You need an sdrmap username and password. If you already have these, please enter them below.
@@ -597,6 +594,10 @@
   <button type="submit" class="btn btn-primary btn-rounded  btn-block btn-lg p-4 mb-3 my-5" name="aggregators"
           value={{go}}>Apply</button>
 </form>
+<div class="container-fluid mt-2 mb-4 small text-muted" id="emoji_key">
+  <span class="ms-2">🔒 = link to the site's privacy / data policy</span>
+  <span class="ms-3">⚠️ = site does not provide a clear privacy / data policy</span>
+</div>
 <script>
   const box_fields = [
     ["flightradar--is_enabled", "FR_FIELDS", ["flightradar--key"]],


### PR DESCRIPTION
I always assumed the links would take you to that aggregators homepage, not the privacy policy. This PR makes it more clear by having a link to the aggregator homepage and then next to that, a link to their privacy policy. It also makes it more clear which aggregators do not have clear privacy policies.

I also fixed the AirNav Radar privacy policy link.