### PR TITLE
Fix folder path in the final step of `app-install.sh` script

### DIFF
--- a/src/tools/app-install.sh
+++ b/src/tools/app-install.sh
@@ -218,7 +218,7 @@ cd ${APP_DIR}/config || exit_message "can't find ${APP_DIR}/config"
 
 # run the final steps of the setup and then enable the services
 systemctl daemon-reload
-readarray -t services_enable < ./opt/adsb/misc/services
+readarray -t services_enable < /opt/adsb/misc/services
 systemctl enable --now "${services_enable[@]}"
 
 # while the user is getting ready, let's try to pull the key docker


### PR DESCRIPTION
# Before

If I tried to install using the script it will gives the following error

```
gusbell@node:~ $ curl https://raw.githubusercontent.com/dirkhh/adsb-feeder-image/main/src/tools/app-install.sh | sudo bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7752  100  7752    0     0  18724      0 --:--:-- --:--:-- --:--:-- 18769
You appear to be on a debian-style distribution
Cloning into '/tmp/tmp.OX0MZ6iL5V/adsb-feeder'...
remote: Enumerating objects: 40687, done.
remote: Counting objects: 100% (3921/3921), done.
remote: Compressing objects: 100% (595/595), done.
remote: Total 40687 (delta 3518), reused 3386 (delta 3302), pack-reused 36766 (from 3)
Receiving objects: 100% (40687/40687), 6.78 MiB | 12.62 MiB/s, done.
Resolving deltas: 100% (21034/21034), done.
Already on 'main'
Your branch is up to date with 'origin/main'.
--> bash: line 221: ./opt/adsb/misc/services: No such file or directory <--
Too few arguments.
Running as unit: adsb-docker-pull.service; invocation ID: 72adfe5125514a45bea9404f6eeb2994
done installing
you can uninstall this software by running
sudo bash /opt/adsb/app-uninstall

you can access the web interface at http://localhost:1099 or http://10.1.0.250:1099
```

# After

After fixing the script run without any issues

```
gusbell@node:~ $ sudo ./install.sh
You appear to be on a debian-style distribution
Cloning into '/tmp/tmp.gehR6EIYkg/adsb-feeder'...
remote: Enumerating objects: 40687, done.
remote: Counting objects: 100% (3859/3859), done.
remote: Compressing objects: 100% (632/632), done.
remote: Total 40687 (delta 3448), reused 3287 (delta 3203), pack-reused 36828 (from 3)
Receiving objects: 100% (40687/40687), 6.78 MiB | 12.79 MiB/s, done.
Resolving deltas: 100% (21035/21035), done.
Already on 'main'
Your branch is up to date with 'origin/main'.
Created symlink '/etc/systemd/system/multi-user.target.wants/adsb-docker.service' → '/usr/lib/systemd/system/adsb-docker.service'.
Created symlink '/etc/systemd/system/default.target.wants/adsb-early-boot.service' → '/usr/lib/systemd/system/adsb-early-boot.service'.
Created symlink '/etc/systemd/system/multi-user.target.wants/adsb-setup.service' → '/usr/lib/systemd/system/adsb-setup.service'.
Created symlink '/etc/systemd/system/timers.target.wants/adsb-update.timer' → '/usr/lib/systemd/system/adsb-update.timer'.
Running as unit: adsb-docker-pull.service; invocation ID: 7eada6d9c34f41ee9a0417a874d7fcaa
done installing
you can uninstall this software by running
sudo bash /opt/adsb/app-uninstall

you can access the web interface at http://localhost:1099 or http://10.1.0.250:1099
```

