### PR TITLE
add sonde_web_control

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -2390,6 +2390,8 @@ class AdsbIm:
                 "sonde_max_freq",
                 "sonde_callsign",
                 "sonde_share_position",
+                "sonde_web_control",
+                "sonde_web_password",
             ]
             for p in placeholders:
                 value = self._d.env_by_tags(p).value

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/advanced.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/advanced.html
@@ -938,6 +938,26 @@
                       submit_button="sonde--update"
                       value="{{ env_value_by_tag('sonde_share_position') }}">
               </div>
+              <div class="col-4 mb-1">
+                <label for="sonde_web_control">
+                  Sonde enable web control
+                </label>
+              </div>
+              <div class="col-8 mb-1">
+                <input type="text" class="mx-auto w-100" name="sonde_web_control" id="sonde_web_control"
+                      submit_button="sonde--update"
+                      value="{{ env_value_by_tag('sonde_web_control') }}">
+              </div>
+              <div class="col-4 mb-1">
+                <label for="sonde_web_password">
+                  Sonde enable web password
+                </label>
+              </div>
+              <div class="col-8 mb-1">
+                <input type="text" class="mx-auto w-100" name="sonde_web_password" id="sonde_web_password"
+                      submit_button="sonde--update"
+                      value="{{ env_value_by_tag('sonde_web_password') }}">
+              </div>
               {% if env_value_by_tag('sondeserial') == '' %}
               <div class="col-12 mb-1 text-warning">
                 <p>No SDR is assigned for Sonde - you can change that on the <a href="/sdr_setup">SDR Setup</a> page.</p>

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
@@ -823,6 +823,8 @@ class Data:
         Env("SONDE_MAX_FREQ", default="406.00", tags=["sonde_max_freq"]),
         Env("SONDE_CALLSIGN", default="ADSBIMDEFAULT", tags=["sonde_callsign"]),
         Env("SONDE_SHARE_POSITION", default="False", tags=["sonde_share_position"]),
+        Env("SONDE_WEB_CONTROL", default="False", tags=["sonde_web_control"]),
+        Env("SONDE_WEB_PASSWORD", default="none", tags=["sonde_web_password"]),
         # Skystats related stuff
         Env("AF_IS_SKYSTATS_ENABLED", default=False, tags=["skystats", "is_enabled"]),
         Env("AF_IS_SKYSTATS_DB_ENABLED", default=False, tags=["skystats_db", "is_enabled"]),

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/radiosonde/station.cfg.template
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/radiosonde/station.cfg.template
@@ -329,12 +329,12 @@ archive_age = 120
 # Enable control over the scanner, and starting/stopping decoders from the web interface.
 # A password must also be set (below).
 # USERS ENABLE THIS AT THEIR OWN RISK!!
-web_control = False
+web_control = %sonde_web_control%
 
 # Password for controls on the web interface. The main interface will still be publicly available.
 # Note that as the web interface is HTTP-only, this password will be sent over the internet in the clear,
 # so don't re-use passwords!
-web_password = none
+web_password = %sonde_web_password%
 
 # KML refresh rate
 kml_refresh_rate = 10


### PR DESCRIPTION
radiosonde_auto_rx [supports](https://github.com/projecthorus/radiosonde_auto_rx/wiki/Web-Interface-Guide#advanced-controls) manual control of the scan web-interface. As there are options for radio sonde under adsb.im's "advanced" tab anyways this can now be enabled there.

Closes #375 