### PR TITLE
Fix crashes and unhandled exceptions across adsb-setup

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -540,7 +540,7 @@ class AdsbIm:
             config = result.stdout.decode("utf-8")
         except Exception:
             config = "Storage=auto"
-        for line in config:
+        for line in config.splitlines():  # was iterating chars, not lines
             if line.startswith("Storage=volatile"):
                 self._persistent_journal = False
                 break
@@ -3269,7 +3269,7 @@ class AdsbIm:
             daemon_json = {}
         new_daemon_json = daemon_json.copy()
         if value:
-            del new_daemon_json["max-concurrent-downloads"]
+            new_daemon_json.pop("max-concurrent-downloads", None)  # del raises KeyError if missing
         else:
             new_daemon_json["max-concurrent-downloads"] = 1
         if new_daemon_json != daemon_json:
@@ -4421,8 +4421,7 @@ class AdsbIm:
             try:
                 result = (
                     subprocess.run(
-                        ["zerotier-cli", "get", f"{zt_network}", "ip4"],
-                        shell=True,
+                        ["zerotier-cli", "get", f"{zt_network}", "ip4"],  # shell=True with list args breaks arg passing
                         capture_output=True,
                         timeout=2.0,
                     )

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/agg_status.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/agg_status.py
@@ -102,7 +102,7 @@ class AggStatus:
             mlat_json = json.load(open(path, "r"))
             percent_good = mlat_json.get("good_sync_percentage_last_hour", 0)
             percent_bad = mlat_json.get("bad_sync_percentage_last_hour", 0)
-            now = mlat_json.get("now")
+            now = mlat_json.get("now", 0)  # default to 0; None causes TypeError below
         except Exception:
             self._mlat = T.Disconnected
             return
@@ -210,8 +210,8 @@ class AggStatus:
         elif container_status == "up":
             pass
         elif "up for" in container_status:
-            _, _, uptime = container_status.split(" ")
-            uptime = int(uptime)
+            parts = container_status.split(" ")  # safe unpack; 3-part tuple unpack crashed on bad format
+            uptime = int(parts[2]) if len(parts) >= 3 else 0
             if self._agg not in ultrafeeder_aggs:
                 if uptime < 60:
                     self._beast = T.Starting
@@ -590,7 +590,7 @@ class Healthcheck:
                 now = obj.get("now")
                 if not now or now < time.time() - 60:
                     fail.append("readsb stats.json out of date")
-                local = obj.get("total").get("local")
+                local = obj.get("total", {}).get("local")  # chained get; "total" may be absent
                 if local and self._d.env_by_tags("readsb_device_type").value != "modesbeast":
                     samples = local.get("samples_processed")
                     if samples == self.lastReadsbSamples:
@@ -629,7 +629,7 @@ class Healthcheck:
                 print_err(traceback.format_exc())
                 fail.append("readsb not running / 1090 SDR probably dead / unplugged")
 
-            hours = self._d.env_by_tags("healthcheck_noplane_hours_1090").value
+            hours = float(self._d.env_by_tags("healthcheck_noplane_hours_1090").value or 0)  # .value is str
             if self.last1090.tooLong(hours):
                 fail.append(f"no planes 1090 for {hours}h")
 
@@ -655,7 +655,7 @@ class Healthcheck:
                 print_err(traceback.format_exc())
                 fail.append("dump978 not running / 978 SDR probably dead / unplugged")
 
-            hours = self._d.env_by_tags("healthcheck_noplane_hours_978").value
+            hours = float(self._d.env_by_tags("healthcheck_noplane_hours_978").value or 0)  # .value is str
             if self.last978.tooLong(hours):
                 fail.append(f"no planes 978 for {hours}h")
 

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/netconfig.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/netconfig.py
@@ -69,7 +69,7 @@ class UltrafeederConfig:
 
     def generate(self):
         is_stage2 = self._d.is_enabled("stage2")
-        num_micro = self._d.env_by_tags("num_micro_sites").value
+        num_micro = int(self._d.env_by_tags("num_micro_sites").value or 0)  # .value is str; > comparison needs int
         # when not in stage2 mode, no point in setting up the others
         if self._micro > 0 and not is_stage2:
             return ""

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/other_aggregators.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/other_aggregators.py
@@ -495,6 +495,9 @@ class OpenSky(Aggregator):
 
     def _activate(self, user_input: str, idx: int = 0) -> bool:
         self._idx = make_int(idx)
+        if "::" not in user_input:  # split("::") without separator raises ValueError
+            print_err(f"OpenSky: expected '::' separator in input")
+            return False
         serial, user = user_input.split("::")
         print_err(f"passed in {user_input} seeing user |{user}| and serial |{serial}|")
         if not user:
@@ -567,6 +570,9 @@ class Sdrmap(Aggregator):
 
     def _activate(self, user_input: str, idx: int = 0) -> bool:
         self._idx = make_int(idx)
+        if "::" not in user_input:  # split("::") without separator raises ValueError
+            print_err(f"Sdrmap: expected '::' separator in input")
+            return False
         password, user = user_input.split("::")
         print_err(f"passed in {user_input} seeing user |{user}| and password |{password}|")
         if not user:

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/system.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/system.py
@@ -216,7 +216,7 @@ class System:
             requests.Timeout,
             requests.RequestException,
         ) as err:
-            status = err.errno if err.errno else -1
+            status = getattr(err, "errno", None) or -1  # not all request exceptions have errno
         except Exception:
             status = -1
         else:
@@ -273,7 +273,7 @@ class System:
             )
             output = result.stdout.decode("utf-8")
             for line in output.split("\n"):
-                if line and line[1] == '"' and line[-2] == '"':
+                if len(line) >= 3 and line[1] == '"' and line[-2] == '"':  # guard short lines
                     # the names show up as '"ultrafeeder"'
                     containers.append(line[2:-2])
         except subprocess.SubprocessError as e:

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/util.py
@@ -178,10 +178,10 @@ def generic_get_json(url: str, data: Optional[Any] = None, timeout: float = 5.0)
         requests.RequestException,
     ) as err:
         print_err(f"checking {url} failed: {err}")
-        status = err.errno if err.errno else -1
+        status = getattr(err, "errno", None) or -1  # not all request exceptions have errno
     except Exception:
         # for some reason this didn't work
-        print_err("checking {url} failed: reason unknown")
+        print_err(f"checking {url} failed: reason unknown")
     else:
         return json_response, response.status_code
     return None, status
@@ -371,9 +371,9 @@ def get_plain_url(plain_url: str, method: str = "GET", data: Optional[str] = Non
         requests.RequestException,
     ) as err:
         print_err(f"checking {plain_url} failed: {err}")
-        status = err.errno if err.errno else -1
+        status = getattr(err, "errno", None) or -1  # not all request exceptions have errno
     except Exception:
-        print_err("checking {plain_url} failed: {traceback.format_exc()}")
+        print_err(f"checking {plain_url} failed: {traceback.format_exc()}")
     else:
         return response.text, response.status_code
     return None, status


### PR DESCRIPTION
## Summary

Fixes 13 crash-causing bugs across 6 files in the `adsb-setup` application. Each fix addresses a specific unhandled exception or incorrect operation that could crash or silently fail at runtime.

## Changes

### `app.py`

- **Line 543** — `for line in config.splitlines():` — Was `for line in config:` which iterates characters of a string, not lines. `startswith("Storage=volatile")` could never match a single character, so persistent journal detection was broken.

- **Line 3272** — `new_daemon_json.pop("max-concurrent-downloads", None)` — Was `del new_daemon_json[...]` which raises `KeyError` if the key doesn't exist in the daemon.json.

- **Line 4424** — Removed `shell=True` from `subprocess.run(["zerotier-cli", "get", ...])` — Using `shell=True` with a list argument causes the args to become positional parameters to `/bin/sh` instead of arguments to `zerotier-cli`, silently breaking the command.

### `utils/util.py`

- **Line 181** — `status = getattr(err, "errno", None) or -1` — Was `err.errno` which raises `AttributeError` since not all `requests` exceptions have an `errno` attribute.

- **Line 184** — Added `f` prefix: `f"checking {url} failed: reason unknown"` — Was a plain string with literal braces instead of an f-string, so the URL was never interpolated.

- **Line 374** — `status = getattr(err, "errno", None) or -1` — Same `errno` fix as line 181, in `get_plain_url`.

- **Line 376** — Added `f` prefix: `f"checking {plain_url} failed: {traceback.format_exc()}"` — Same missing f-string issue as line 184.

### `utils/system.py`

- **Line 219** — `status = getattr(err, "errno", None) or -1` — Same `errno` fix in `check_ip()`.

- **Line 276** — `if len(line) >= 3 and line[1] == '"' ...` — Was `if line and line[1] == '"'` which crashes with `IndexError` on 1-character lines from `docker ps` output.

### `utils/agg_status.py`

- **Line 105** — `now = mlat_json.get("now", 0)` — Was `.get("now")` which returns `None`, then `time.time() - None` raises `TypeError`.

- **Lines 213-214** — Safe unpacking of `container_status.split(" ")` — Was `_, _, uptime = container_status.split(" ")` which raises `ValueError` if the string doesn't have exactly 3 parts.

- **Line 593** — `obj.get("total", {}).get("local")` — Was `obj.get("total").get("local")` which raises `AttributeError` when `"total"` key is missing.

- **Lines 632, 658** — `float(self._d.env_by_tags("healthcheck_noplane_hours_...").value or 0)` — `.value` returns a string, which was then used directly in `<=` and `*` arithmetic comparisons, causing `TypeError`.

### `utils/netconfig.py`

- **Line 72** — `int(self._d.env_by_tags("num_micro_sites").value or 0)` — `.value` returns a string, which was compared with `>` against an integer, causing incorrect behavior (string vs int comparison).

### `utils/other_aggregators.py`

- **Lines 498-500** — Added `"::" not in user_input` guard in `OpenSky._activate` — `user_input.split("::")` unpacking crashes with `ValueError` if separator is missing.

- **Lines 573-575** — Same `"::"` guard in `Sdrmap._activate`.

## Test plan

- [x] All files pass `python3 -m py_compile` syntax check
- [x] All 368 unit tests pass
- [ ] Manual verification on a running feeder instance