### PR TITLE
Fix airplanes.live privacy policy URL

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/aggregators.html
@@ -124,7 +124,7 @@
     <input type="checkbox" class="form-check-input me-1 ultrafeeder" name="is_enabled--ultrafeeder--alive" id="is_enabled--alive"
            {{ uf_enabled("alive", m) }} onclick="$('#individual').click();"/>
     <label for="is_enabled--alive">
-      <a href="https://airplanes.live/">airplanes.live</a> <a href="https://airplanes.live/privacy" title="Privacy Policy" style="font-size: 0.8em;">🛡️</a>
+      <a href="https://airplanes.live/">airplanes.live</a> <a href="https://airplanes.live/privacy-policy/" title="Privacy Policy" style="font-size: 0.8em;">🛡️</a>
     </label>
   </div>
   <div class="col-xl-2 col-lg-3 col-sm-4 form-check">


### PR DESCRIPTION
## Summary
- The airplanes.live privacy policy link in `aggregators.html` points to `https://airplanes.live/privacy`, which returns a 404.
- The page is now served at `https://airplanes.live/privacy-policy/` (the old URL doesn't even redirect — it's a hard 404).
- One-line fix.

## Test plan
- [x] Confirmed `curl -I https://airplanes.live/privacy` returns `HTTP/2 404`
- [x] Confirmed `curl -I https://airplanes.live/privacy-policy/` returns `HTTP/2 200`
- [ ] Reviewer: visit the Data Sharing page and click the 🛡️ next to airplanes.live to verify