### PR TITLE
better BME280 detection

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/extras/temperature.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/extras/temperature.py
@@ -54,8 +54,8 @@ def run_subprocess(command, timeout=180):
 
 class BME280_i2c:
     def __init__(self):
-        # check that i2c is enabled
-        self.success, output = run_subprocess("lsmod | grep i2c_bcm2835 2> /dev/null", timeout=5)
+        # check that i2c is enabled (should work on more RPi boards)
+        self.success, output = run_subprocess("lsmod | grep i2c_bcm 2> /dev/null", timeout=5)
         if not self.success:
             logger.info("i2c is not enabled")
             return
@@ -74,15 +74,23 @@ class BME280_i2c:
                 self.success = False
                 logger.info("Failed to import bme280 and smbus2")
                 return
-        # BME280 sensor address (default address)
-        self.address = 0x77
 
-        # Initialize I2C bus
-        self.bus = smbus2.SMBus(1)
-        self.bme280 = bme280
-
-        # Load calibration parameters
-        self.calibration_params = self.bme280.load_calibration_params(self.bus, self.address)
+        # BME280 sensor potential addresses
+        addresses = [0x77, 0x76]
+        for address_probe in addresses:
+            try:
+                # Load calibration parameters
+                self.calibration_params = self.bme280.load_calibration_params(self.bus, address_probe)
+                self.address = address_probe
+                logger.info(f"Found BME280 at address {address_probe:#x}")
+                self.success = True
+                break
+            except Exception:
+                continue
+        else:
+            logger.info("Could not find BME280 on i2c bus")
+            self.address = None
+            self.success = False
 
     def get_temperature(self):
         if not self.success:


### PR DESCRIPTION
This should improve detection of BME280 sensors at other i2c addresses and also on more RPi boards.

### Why this was done

For background I am using DietPi, the adsb.im app, and it's all running on a Raspberry Pi 5.

I was trying to add a BME280 sensor to my RPi5, but trying to enable temperature sensor detection from the webpage UI kept spitting out "i2c is not enabled" error messages, even after enabling i2c with the dietpi terminal config and confirming it's enabled.

First issue was the kernel module detection, originally the script was looking for `i2c_bcm2835` but on a RPi 5 it's using `i2c_bcm2708`. Second, my BME280 sensor was on address `0x76` as shown by `i2cdetect -y 1` whereas the script just hardcoded it at `0x77`.