### PR TITLE
[Feature] Add FlightGazer detection and proxying

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -362,6 +362,14 @@ class AdsbIm:
             if entry[0] in netconfigs.keys():
                 self.uf_aggregators.append(entry)
 
+        # check if FlightGazer is running on this image or alongside the app on this system
+        # before we compile all the proxy routes
+        self._d.env_by_tags("flightgazer_proxy").value = self._service_exists("flightgazer-webapp.service")
+        if self._d.is_enabled("flightgazer_proxy") and not any(
+            endpoint == "/flightgazer/" for endpoint, _, _ in self._d._proxy_routes
+        ):
+            self._d._proxy_routes.append(["/flightgazer/", "FLIGHTGAZER", "/flightgazer/"])
+
         self._routemanager.add_proxy_routes(self._d.proxy_routes)
         self.app.add_url_rule("/geojson", "geojson", self.geojson)
         self.app.add_url_rule("/icons.png", "iconspng", self.iconspng)
@@ -2753,6 +2761,15 @@ class AdsbIm:
             self._d.env_by_tags("sonde").value = True
         if self._d.is_enabled("is_ais_feeder"):
             self._d.env_by_tags("shipfeeder").value = True
+
+    def _service_exists(self, service_name: str) -> bool:
+        if not service_name:
+            return False
+        success, _ = run_shell_captured(
+            f"systemctl list-unit-files --type=service {service_name} 2>/dev/null | grep -q '^{service_name}\\s'",
+            timeout=5,
+        )
+        return success
 
     def handle_temp_sensor(self, temp_sensor, dht22_pin=0):
         if temp_sensor.value == "dht22":

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/base.html
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/templates/base.html
@@ -176,6 +176,9 @@
             {% if is_enabled('skystats') %}
             <li><a class="dropdown-item" href="/skystats/">Skystats</a></li>
             {% endif %}
+            {% if is_enabled('flightgazer_proxy') %}
+            <li><a class="dropdown-item" href="/flightgazer/">FlightGazer</a></li>
+            {% endif %}
           </ul>
             </li>
       </ul>

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
@@ -97,6 +97,7 @@ class Data:
         ["/acarshub/", "ACARSHUB", "/"],
         ["/aiscatcher/", "AISCATCHER", "/"],
         ["/radiosonde/", "RADIOSONDE", "/"],
+        ["/flightgazer/", "FLIGHTGAZER", "/flightgazer/"],
     ]
 
     @property
@@ -551,6 +552,8 @@ class Data:
         Env("AF_FLIGHTRADAR_PORT", default=8754, tags=["frport"]),
         Env("AF_PLANEFINDER_PORT", default=30053, tags=["pfport"]),
         Env("AF_SKYSTATS_PORT", default=5173, tags=["skystatsport", "norestore"]),
+        Env("AF_FLIGHTGAZER_PORT", default=9898, tags=["flightgazerport", "norestore"]),
+        Env("AF_IS_FLIGHTGAZER_PROXY_ENABLED", default=False, tags=["flightgazer_proxy", "is_enabled"]),
         Env("AF_DOCKER_IPV6", default=False, tags=["docker_ipv6", "is_enabled", "norestore"]),
         Env("AF_TELEGRAF_ADSB", default=False, tags=["telegraf_adsb", "is_enabled"]),
         Env("TELEGRAF_URL_1090", default="", tags=["telegraf_url_1090"]),


### PR DESCRIPTION
This PR allows both the adsb.im image and app to detect and successfully add a proxy route (`/flightgazer`) for the FlightGazer webapp when it's running on the same system.

UI changes are limited to just adding another entry to the System dropdown.

<img width="301" height="440" alt="image" src="https://github.com/user-attachments/assets/e5f4ef9b-c8b1-4ab4-b9f2-9020620a5795" />

## Why?

- When running the image, the root route (e.g. typing `adsb-feeder.local` in a browser) is handled by the main adsb.im page and handles all the proxying for related containers and other pages
- Mucking around with adding a separate webserver on an existing image and doing the required proxying to get to the `/flightgazer` endpoint is a headache in itself and fragile
- [FlightGazer](https://github.com/WeegeeNumbuh1/FlightGazer) is another ADS-B-related project and has had long-standing adsb.im support both in the main project and the [web-app](https://github.com/WeegeeNumbuh1/FlightGazer-webapp#what-it-looks-like) (I personally build against a few of my systems running adsb.im images)

## How to test

I didn't write any unit tests for this as I just edit on my personal live production systems. As of this PR, the changes are tested against [`v3.0.13-beta.5`](https://github.com/dirkhh/adsb-feeder-image/commit/25aed6926b887c1dc8ed2045e6eb38b97037a88c).

This PR simply checks if the `flightgazer-webapp.service` exists on the running system when the adsb.im service starts, you can probably just add a dummy service with that name to validate the behavior without having to do a full FlightGazer install.

<details><summary>In case you want to fully test</summary>

Note: this will probably require a few hundred megabytes of space as this will install a couple dependencies, [see here](https://github.com/WeegeeNumbuh1/FlightGazer?tab=readme-ov-file#misc)

```bash
git clone --depth=1 https://github.com/WeegeeNumbuh1/FlightGazer && cd FlightGazer
sudo bash FlightGazer-init.sh -c && echo y | sudo bash install-FlightGazer-webapp.sh
```

</details>

Appending `/flightgazer` to the end of the URL from the main adsb.im page in a browser should redirect to the webapp page when adsb.im detects the service, same with clicking on the entry in the dropdown menu. When the service isn't detected, no proxying is done, and of course, no entry added to the dropdown.

### Other notes

I've tested this change on my setups, including both cases when the FlightGazer-webapp service is present and not:

- adsb.im image on a RPi02W
- adsb.im image in a VM as a stage2 setup
- adsb.im app installed in Diet-Pi
