### PR TITLE
Show OpenSky receiver status

### DIFF
--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/app.py
@@ -297,7 +297,7 @@ class AdsbIm:
             ["radarbox", "AirNav Radar", "https://www.airnavradar.com/coverage-map", ["https://www.airnavradar.com/stations/<FEEDER_RADARBOX_SN>"], 1],
             ["planefinder", "PlaneFinder", "https://planefinder.net/", ["/planefinder-statSTG2IDX/"], 1],
             ["adsbhub", "ADSBHub", "https://www.adsbhub.org/coverage.php", [""], 1],
-            ["opensky", "OpenSky", "https://map.opensky-network.org/", ["https://opensky-network.org/my-opensky/sensors/view-sensors"], 1],
+            ["opensky", "OpenSky", "https://map.opensky-network.org/", ["https://opensky-network.org/data/sensor-details?serial=<FEEDER_OPENSKY_SERIAL>"], 1],
             ["1090uk", "1090MHz UK", "https://1090mhz.uk", ["https://www.1090mhz.uk/mystatus.php?key=<FEEDER_1090UK_API_KEY>"], 1],
             ["sdrmap", "sdrmap", "https://sdrmap.org/", ["https://sdrmap.org/?station=<FEEDER_SM_USERNAME>"], 1],
             ["radarvirtuel", "RadarVirtuel", "https://www.radarvirtuel.com/", [""], 1],

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/agg_status.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/agg_status.py
@@ -8,6 +8,7 @@ import traceback
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Optional
+from urllib.parse import urlencode
 
 from .data import Data
 from .paths import PREVIOUS_VERSION_FILE
@@ -49,6 +50,8 @@ class AggStatus:
         self._url = url
         self._system = system
         self.ultrafeeder_aggs = list(data.netconfigs.keys())
+        self._opensky_data_status = T.Unknown
+        self._opensky_data_next_check = 0.0
 
     @property
     def beast(self) -> str:
@@ -107,6 +110,41 @@ class AggStatus:
             self._mlat = T.Warning
 
         return
+
+    def get_opensky_data_status(self):
+        now = time.time()
+        if now < self._opensky_data_next_check:
+            self._beast = self._opensky_data_status
+            return
+
+        serial = str(self._d.env_by_tags(["opensky", "key"]).list_get(self._idx))
+        if not serial:
+            self._opensky_data_status = T.Unknown
+        else:
+            query = urlencode({"begin": int(now) - 1800, "end": int(now), "serials": serial})
+            status_dict, status = self.get_json(f"https://opensky-network.org/api/stats/msg-rates?{query}")
+            self._opensky_data_status = T.Unknown
+            if status == 200 and isinstance(status_dict, dict):
+                series = status_dict.get("series")
+                if isinstance(series, dict):
+                    samples = series.get(serial)
+                    if not samples:
+                        self._opensky_data_status = T.Disconnected
+                    else:
+                        try:
+                            sample_time_ms, messages_per_minute = samples[-1]
+                            sample_age = now - float(sample_time_ms) / 1000
+                            if sample_age < 300 and float(messages_per_minute) > 0:
+                                self._opensky_data_status = T.Good
+                            elif sample_age < 1800:
+                                self._opensky_data_status = T.Warning
+                            else:
+                                self._opensky_data_status = T.Disconnected
+                        except (IndexError, TypeError, ValueError):
+                            pass
+
+        self._opensky_data_next_check = now + 60
+        self._beast = self._opensky_data_status
 
     def get_beast_status(self):
         bconf = None
@@ -328,7 +366,7 @@ class AggStatus:
             self._mlat = T.Disabled
             self._last_check = datetime.now()
         elif self._agg == "opensky":
-            self._beast = T.Unknown
+            self.get_opensky_data_status()
             self._mlat = T.Disabled
             self._last_check = datetime.now()
         elif self._agg == "radarvirtuel":

--- a/tests/unit/test_opensky_status.py
+++ b/tests/unit/test_opensky_status.py
@@ -1,0 +1,74 @@
+"""Tests for OpenSky receiver status reporting."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from utils.agg_status import AggStatus, T
+
+
+def make_status(serial="-1408237521"):
+    data = MagicMock()
+    data.netconfigs = {}
+    data.env_by_tags.return_value.list_get.return_value = serial
+    system = MagicMock()
+    system.getContainerStatus.return_value = "up"
+    return AggStatus("opensky", 0, data, "http://127.0.0.1", system)
+
+
+@pytest.mark.parametrize(
+    ("sample_age", "messages_per_minute", "expected"),
+    [
+        (60, 100, T.Good),
+        (60, 0, T.Warning),
+        (600, 100, T.Warning),
+        (1801, 100, T.Disconnected),
+    ],
+)
+def test_status_uses_sensor_page_thresholds(sample_age, messages_per_minute, expected):
+    now = 2_000_000_000
+    serial = "-1408237521"
+    status = make_status(serial)
+    status.get_json = MagicMock(return_value=({"series": {serial: [[(now - sample_age) * 1000, messages_per_minute]]}}, 200))
+
+    with patch("utils.agg_status.time.time", return_value=now):
+        status.get_opensky_data_status()
+
+    assert status._beast == expected
+
+
+def test_status_distinguishes_offline_from_api_failure():
+    offline = make_status()
+    offline.get_json = MagicMock(return_value=({"series": {}}, 200))
+    unavailable = make_status()
+    unavailable.get_json = MagicMock(return_value=(None, -1))
+
+    with patch("utils.agg_status.time.time", return_value=2_000_000_000):
+        offline.get_opensky_data_status()
+        unavailable.get_opensky_data_status()
+
+    assert offline._beast == T.Disconnected
+    assert unavailable._beast == T.Unknown
+
+
+def test_status_skips_request_without_serial():
+    status = make_status(serial="")
+    status.get_json = MagicMock()
+
+    with patch("utils.agg_status.time.time", return_value=2_000_000_000):
+        status.get_opensky_data_status()
+
+    assert status._beast == T.Unknown
+    status.get_json.assert_not_called()
+
+
+def test_status_is_cached_for_one_minute():
+    now = 2_000_000_000
+    serial = "-1408237521"
+    status = make_status(serial)
+    status.get_json = MagicMock(return_value=({"series": {serial: [[now * 1000, 100]]}}, 200))
+
+    with patch("utils.agg_status.time.time", side_effect=[now, now + 30]):
+        status.get_opensky_data_status()
+        status.get_opensky_data_status()
+
+    status.get_json.assert_called_once()


### PR DESCRIPTION
Hi!

This is an implementation of providing the status of the OpenSky receiver, it uses an API that we also use on https://opensky-network.org/data/sensor-details?serial=<FEEDER_OPENSKY_SERIAL>"

I have tested it for a few days on a local feeder - works well as far as I can see. Let me know any feedback.

Unit tests written by Codex.