### PR TITLE
add map.flights as an account-less aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These ADS-B aggregators are also supported:
 - [FlightAware](https://flightaware.com)
 - [Flightradar24](https://www.flightradar24.com)
 - [hpradar](https://skylink.hpradar.com/)
+- [map.flights](https://map.flights)
 - [OpenSky Network](https://opensky-network.org)
 - [Plane.watch](https://plane.watch)
 - [Plane Finder](https://planefinder.net)

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,6 @@
 Changes since v3.0.12
 =======
+- add map.flights as an account-less aggregator
 - add new aggregators: ADSBiq, RealTraffic, Dataero, FlyOverhead, flightdeck, adsbitalia
 - webUI: completely rethink and redo the data sharing page
 - stage2: always show Data Sharing link / show explanation for combined target

--- a/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
+++ b/src/modules/adsb-feeder/filesystem/root/opt/adsb/adsb-setup/utils/data.py
@@ -254,6 +254,17 @@ class Data:
             policy="https://flyoverhead.com/legal/privacy",
         ),
         NetConfig(
+            identifier="mapflights",
+            name="map.flights",
+            website="https://map.flights/",
+            links=["https://map.flights/receivers"],
+            table=1,
+            ordinal=86,
+            adsb_config="adsb,feed.map.flights,30004,beast_reduce_plus_out",
+            mlat_config="",
+            policy="https://map.flights/privacy",
+        ),
+        NetConfig(
             identifier="flyrealtraffic",
             name="RealTraffic",
             website="https://flyrealtraffic.com/",


### PR DESCRIPTION
map.flights is an account-less, semi-anonymous ADS-B aggregator: no signup, no API key, nothing to enter to start feeding. Adding the NetConfig entry is all that is needed - the env vars (_ADSBIM_STATE_IS_ULTRAFEEDER_MAPFLIGHTS_ENABLED and ULTRAFEEDER_MAPFLIGHTS_UUID), the Data Sharing checkbox, the microfeeder setting tags and the feed status check are all derived from netconfigs.

Details:
- adsb: adsb,feed.map.flights,30004,beast_reduce_plus_out
- mlat: not offered, so mlat_config is empty (status shows as disabled, same as FlyOverhead / FlightDeck)
- UUID: bring-your-own, the feeder's generated UUID is accepted as is; entering the same UUID on https://map.flights/receivers claims the station and gives it a public profile
- status link points at the receivers page, privacy policy at https://map.flights/privacy

Placed at ordinal 86 so it shows up next to the other recently added account-less aggregators rather than in the top group of four.

Offered by the operator in #420.

Note: rebased on top of current `main` — the new required `table` parameter is set (`table=1`, second table of the reworked Data Sharing page, between FlyOverhead and RealTraffic; happy to move it, it's a one-number change).

Testing: `pytest tests/` passes (373 passed on top of current `main`), flake8 / black / ruff clean. Loading `utils.data.Data` directly confirms the derived env vars and the generated Ultrafeeder line `adsb,feed.map.flights,30004,beast_reduce_plus_out,uuid=<uuid>`. I have not run a full image build.